### PR TITLE
Docker Compatibility & Automatic Git Dir Variable

### DIFF
--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -32,10 +32,10 @@ update='December 26, 2020'
 # Project Home: https://github.com/stevejenkins/pihole-cloudsync
 ###########################################################################
 # CONSTANTS
-personal_git_dir='/usr/local/bin/my-pihole-lists'
-pihole_dir='/etc/pihole'
-gravity_db='/etc/pihole/gravity.db'
-dnsmasq_dir='/etc/dnsmasq.d/'
+personal_git_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pihole_dir='/etc/pihole' # No trailing slash '/'
+dnsmasq_dir='/etc/dnsmasq.d' # No trailing slash '/'
+gravity_db_filename='gravity.db'
 ad_list='adlist.csv'
 custom_list='custom.list'
 domain_list='domainlist.csv'
@@ -46,8 +46,35 @@ cname_list='05-pihole-custom-cname.conf'
 # Force sudo if not running with root privileges
 SUDO=''
 if [ "$EUID" -ne 0 ]
-  then SUDO='sudo'
+then
+	SUDO='sudo'
 fi
+
+# Send pihole commands via docker exec if pihole is running in docker container
+PIHOLECONTAINER=''
+DOCKER=''
+if [ -x "$(command -v docker)" ]
+then
+	PIHOLECONTAINER=$(docker ps -f "ancestor=pihole/pihole" --format "{{.Names}}")
+	if [ -n "${PIHOLECONTAINER}" ] && $(docker inspect -f "{{.State.Running}}" "${PIHOLECONTAINER}")
+	then
+		if ! command -v jq >/dev/null 2>&1 ; then
+			echo "jq not found. Please install using 'sudo apt-get install jq' or equivalent for your distro."
+		fi
+
+		echo "pihole is running under docker. Using container '$PIHOLECONTAINER'"
+
+		pihole_dir=$(docker inspect -f "{{json .Mounts}}" "${PIHOLECONTAINER}" | jq -r --arg pihole_dir "$pihole_dir" '.[] | select(.Destination==$pihole_dir) | .Source')
+		dnsmasq_dir=$(docker inspect -f "{{json .Mounts}}" "${PIHOLECONTAINER}" | jq -r --arg dnsmasq_dir "$dnsmasq_dir" '.[] | select(.Destination==$dnsmasq_dir) | .Source')
+
+		echo "Found pihole directory mapping at $pihole_dir"
+		echo "Found dnsmasq directory mapping at $dnsmasq_dir"
+
+		DOCKER="docker exec -i ${PIHOLECONTAINER}"
+	fi
+fi
+
+gravity_db="$pihole_dir/$gravity_db_filename"
 
 # FUNCTIONS
 push_initialize () {
@@ -66,6 +93,8 @@ push_initialize () {
 	cd $personal_git_dir || exit
 
 	# Export Ad and Domain lists from Gravity database
+	echo "Reading from gravity db located at $gravity_db"
+
 	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM adlist" >$ad_list
 	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM domainlist" >$domain_list
 
@@ -85,7 +114,7 @@ pull_initialize () {
 	$SUDO git reset --hard origin/master -q
 
 	# Stop DNS server
-	$SUDO service pihole-FTL stop
+	$SUDO $DOCKER service pihole-FTL stop
 
 	# Overwrite local files
 	$SUDO cp $custom_list $pihole_dir
@@ -98,120 +127,132 @@ pull_initialize () {
 	$SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
 
 	# Restart Pi-hole to pick up changes
-	$SUDO pihole -g
+	$SUDO $DOCKER pihole -g
 
 	# Display success messages
 	echo "Local Pi-hole initialized in Pull mode and first pull successfully completed.";
 	echo "Future pulls can now be perfomed with 'pihole-cloudsync --pull'.";
 }
 push () {
-	 # Go to Pi-hole directory, exit if doesn't exist
+	# Go to Pi-hole directory, exit if doesn't exist
 	cd $pihole_dir || exit
 
-        # Copy local Custom and CNAME lists to local Git repo
-        $SUDO cp $custom_list $personal_git_dir
-        $SUDO cp $dnsmasq_dir/$cname_list $personal_git_dir
+	# Copy local Custom and CNAME lists to local Git repo
+	$SUDO cp $custom_list $personal_git_dir
+	$SUDO cp $dnsmasq_dir/$cname_list $personal_git_dir
 
 	# Go to local Git repo directory
-        cd $personal_git_dir || exit
+	cd $personal_git_dir || exit
 
-        # Export Ad and Domain lists from Gravity database
-        $SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM adlist" >$ad_list
-        $SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM domainlist" >$domain_list
+	# Export Ad and Domain lists from Gravity database
+	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM adlist" >$ad_list
+	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM domainlist" >$domain_list
 
 	# Compare local files to remote Git repo
 	$SUDO git remote update > /dev/null
 
 	# If local files are different than remote, update remote Git repo
-        CHANGED=$($SUDO git --work-tree=$personal_git_dir status --porcelain)
-        if [ -n "${CHANGED}" ]; then
-                echo 'Local Pi-hole lists are different than remote Git repo. Updating remote repo...';
+	CHANGED=$($SUDO git --work-tree=$personal_git_dir status --porcelain)
+	if [ -n "${CHANGED}" ]
+	then
+		echo 'Local Pi-hole lists are different than remote Git repo. Updating remote repo...'
 		rightnow=$(date +"%B %e, %Y %l:%M%p")
 		# Remove -q option if you don't want to run in "quiet" mode
 		$SUDO git commit -a -m "Updated $rightnow" -q
 		$SUDO git push -q
 		echo 'Done!';
 		exit 0
-        else
-	# If local files are the same as remote, do nothing and exit
-	echo 'Remote Git repo matches local Pi-hole lists. No further action required.';
+	else
+		# If local files are the same as remote, do nothing and exit
+		echo 'Remote Git repo matches local Pi-hole lists. No further action required.';
 		exit 0
-        fi
+	fi
 }
 pull () {
-        # Go to Pi-hole directory, exit if doesn't exist
+	# Go to Pi-hole directory, exit if doesn't exist
 	cd $personal_git_dir || exit
 
 	# Update local Git repo from remote Git repo
 	$SUDO git remote update > /dev/null
 	CHANGED=$($SUDO git log HEAD..origin/master --oneline)
-	if [ -n "${CHANGED}" ]; then
-                echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
-                # Remove -q option if you don't want to run in "quiet" mode
-                $SUDO git fetch --all -q
+	if [ -n "${CHANGED}" ]
+	then
+		echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
+		# Remove -q option if you don't want to run in "quiet" mode
+		$SUDO git fetch --all -q
 		$SUDO git reset --hard origin/master -q
-                $SUDO service pihole-FTL stop
-                $SUDO cp $custom_list $pihole_dir
-                $SUDO cp $cname_list $dnsmasq_dir
-                $SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
-                $SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
-                $SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
-                $SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
-		$SUDO pihole -g
-                echo 'Done!';
-                exit 0
-        else
-                echo 'Local Pi-hole lists match remote Git repo. No further action required.';
-                exit 0
-        fi
+		$SUDO $DOCKER service pihole-FTL stop
+		$SUDO cp $custom_list $pihole_dir
+		$SUDO cp $cname_list $dnsmasq_dir
+		$SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
+		$SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
+		$SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
+		$SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
+		$SUDO $DOCKER pihole -g
+		echo 'Done!';
+		exit 0
+	else
+		echo 'Local Pi-hole lists match remote Git repo. No further action required.';
+		exit 0
+	fi
+}
+docker_test() {
+	$DOCKER printenv
 }
 ###########################################################################
 # Check to see whether a command line option was provided
 if [ -z "$1" ]
-  then
-    echo "Missing command line option. Try --push, --pull, or --help."
-    exit 1
+then
+	echo "Missing command line option. Try --push, --pull, or --help."
+	exit 1
 fi
 # Determine which action to perform (InitPush, InitPull, Push, Pull, or Help)
 for arg in "$@"
 do
-    # Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-    if [ "$arg" == "--initpush" ]
-    then
-	echo "$arg option detected. Initializing local Git repo for Push/Upload.";
-	push_initialize
-	exit 0
-    # Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-    elif [ "$arg" == "--initpull" ]
-    then
-	echo "$arg option detected. Initializing local Git repo for Pull/Download.";
-	pull_initialize
-	exit 0
-    # Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
-    elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ]
-    then
-	echo "$arg option detected. Running in Push/Upload mode."
-	push
-	exit 0
-    # Pull / Download - Pulls updated Pi-hole lists from remote Git repo
-    elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ]
-    then
-        echo "$arg option detected. Running in Pull/Download mode."
-	pull
-        exit 0
-    # Help - Displays help dialog
-    elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ]
-    then
-	cat << EOF
+	# Test sending commands to docker container
+	if [ "$arg" == "--dockertest" ]
+	then
+		echo "$arg option detected. Testing docker container commands with 'printenv'.";
+		docker_test
+		exit 0
+	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
+	elif [ "$arg" == "--initpush" ]
+	then
+		echo "$arg option detected. Initializing local Git repo for Push/Upload.";
+		push_initialize
+		exit 0
+	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
+	elif [ "$arg" == "--initpull" ]
+	then
+		echo "$arg option detected. Initializing local Git repo for Pull/Download.";
+		pull_initialize
+		exit 0
+	# Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
+	elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ]
+	then
+		echo "$arg option detected. Running in Push/Upload mode."
+		push
+		exit 0
+	# Pull / Download - Pulls updated Pi-hole lists from remote Git repo
+	elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ] || [ "$arg" == "-d" ]
+	then
+		echo "$arg option detected. Running in Pull/Download mode."
+		pull
+		exit 0
+	# Help - Displays help dialog
+	elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ]
+	then
+		cat << EOF
 Usage: pihole-cloudsync <option>
 
 Options:
-  --push, --upload, --up, -u		Push (upload) your Pi-hole lists to a remote Git repo
-  --pull, --download, --down, -d	Pull (download) your lists from a remote Git repo
-  --initpush				Initialize Primary Pi-hole in "Push" mode
-  --initpull				Initialize Secondary Pi-hole in "Pull" mode
-  --help, -h, -?			Show this help dialog
-  --version, -v				Show the current version of pihole-cloudsync
+  --push, --upload, --up, -u        Push (upload) your Pi-hole lists to a remote Git repo
+  --pull, --download, --down, -d    Pull (download) your lists from a remote Git repo
+  --initpush                        Initialize Primary Pi-hole in "Push" mode
+  --initpull                        Initialize Secondary Pi-hole in "Pull" mode
+  --help, -h, -?                    Show this help dialog
+  --version, -v                     Show the current version of pihole-cloudsync
+  --dockertest                      Validate connection to running Pi-hole docker container
 
 Examples:
   'pihole-cloudsync --push' will push (upload) your lists to a Git repo
@@ -220,15 +261,15 @@ Examples:
 Project Home: https://github.com/stevejenkins/pihole-cloudsync
 EOF
 
-    # Version - Displays version number
-    elif [ "$arg" == "--version" ] || [ "$arg" == "-v" ]
+	# Version - Displays version number
+	elif [ "$arg" == "--version" ] || [ "$arg" == "-v" ]
 	then
-	echo 'pihole-cloudsync v'$version' - Updated '"$update";
-	echo 'https://github.com/stevejenkins/pihole-cloudsync';
+		echo 'pihole-cloudsync v'$version' - Updated '"$update";
+		echo 'https://github.com/stevejenkins/pihole-cloudsync';
 
-    # Invalid command line option was passed
-    else
-	echo "Invalid command line option. Try --push, --pull, or --help."
-	exit 1
-    fi
+	# Invalid command line option was passed
+	else
+		echo "Invalid command line option. Try --push, --pull, or --help."
+		exit 1
+	fi
 done


### PR DESCRIPTION
This is a continuation of #18 by @IarwainBen-adar 

I noticed that there had been no response there for 25 days, and there were some merge conflicts.

I pulled this down and created a branch to work from. This is the sum of my changes added to the changes that @IarwaiBen-adar had made.

I have tested it with Pi-Hole v5 running in docker.
I have a docker container running in UnRAID as the master, and a container on a Raspberrry Pi as a downstream pi-hole. Push and Pull is working great. 

I also made it so that you don't have to set the personal_git_dir repo as it will be set automatically based on the location of the pihole-cloudsync script. It works regardless of where you are when you execute the script.

With this change you also don't need to change the pihole_dir or dnsmasq_dir paths if you are running in a container. It will look for those paths inside of the container and find the mapped volume outside of the container.

I am very open to feedback if you see anything that you don't like or anything that makes it more difficult for those not running a container. I don't have that setup to test, but I don't see anything in my changes that would have a negative impact on non-docker users.

The way that @IarwainBen-adar had this set up was to auto-detect if there is a pihole docker container. If we wanted we could have that be a flag that is passed, but I think this solution is fine since it is very unlikely that someone would have an active pihole container and a local install since they can't both be on port 53.