### PR TITLE
Sync with pihole running in Docker

### DIFF
--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -98,6 +98,11 @@ push_initialize () {
 	echo "Local Pi-hole initialized in Push mode and local lists were added to local Git repo. Run 'pihole-cloudsync --push' to push to remote Git repo.";
 }
 pull_initialize () {
+	branch=$1
+	if [ -z "${branch}" ]; then
+		branch="master"
+	fi
+
 	# Go to Pi-hole directory, exit if doesn't exist
 	cd $personal_git_dir || exit
 
@@ -106,7 +111,7 @@ pull_initialize () {
 
 	# Remove -q option if you don't want to run in "quiet" mode
 	$SUDO git fetch --all -q
-	$SUDO git reset --hard origin/master -q
+	$SUDO git reset --hard "origin/${branch}" -q
 
 	# Stop DNS server
 	$SUDO ${DOCKER} service pihole-FTL stop
@@ -163,17 +168,22 @@ push () {
 	fi
 }
 pull () {
+	branch=$1
+	if [ -z "${branch}" ]; then
+		branch="master"
+	fi
+
 	# Go to Pi-hole directory, exit if doesn't exist
 	cd $personal_git_dir || exit
 
 	# Update local Git repo from remote Git repo
 	$SUDO git remote update > /dev/null
-	CHANGED=$($SUDO git log HEAD..origin/master --oneline)
+	CHANGED=$($SUDO git log HEAD..origin/${branch} --oneline)
 	if [ -n "${CHANGED}" ]; then
 		echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
 		# Remove -q option if you don't want to run in "quiet" mode
 		$SUDO git fetch --all -q
-		$SUDO git reset --hard origin/master -q
+		$SUDO git reset --hard "origin/${branch}" -q
 		$SUDO ${DOCKER} service pihole-FTL stop
 		$SUDO cp $custom_list $pihole_dir
 		$SUDO cp $cname_list $dnsmasq_dir
@@ -205,7 +215,8 @@ for arg in "$@"; do
 	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
 	elif [ "$arg" == "--initpull" ]; then
 		echo "$arg option detected. Initializing local Git repo for Pull/Download.";
-		pull_initialize
+		shift
+		pull_initialize $1
 		exit 0
 	# Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
 	elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ]; then
@@ -215,7 +226,8 @@ for arg in "$@"; do
 	# Pull / Download - Pulls updated Pi-hole lists from remote Git repo
 	elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ]; then
 		echo "$arg option detected. Running in Pull/Download mode."
-		pull
+		shift
+		pull $1
 		exit 0
 	# Help - Displays help dialog
 	elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ]; then
@@ -223,16 +235,17 @@ for arg in "$@"; do
 		Usage: pihole-cloudsync <option>
 
 		Options:
-			--push, --upload, --up, -u    Push (upload) your Pi-hole lists to a remote Git repo
-			--pull, --download, --down, -d  Pull (download) your lists from a remote Git repo
-			--initpush        Initialize Primary Pi-hole in "Push" mode
-			--initpull        Initialize Secondary Pi-hole in "Pull" mode
-			--help, -h, -?      Show this help dialog
+			--push, --upload, --up, -u               Push (upload) your Pi-hole lists to a remote Git repo
+			--pull, --download, --down, -d [branch]  Pull (download) your lists from a remote Git repo
+			--initpush                 Initialize Primary Pi-hole in "Push" mode
+			--initpull [branch]        Initialize Secondary Pi-hole in "Pull" mode with optional branch (default: master)
+			--help, -h, -?       Show this help dialog
 			--version, -v        Show the current version of pihole-cloudsync
 
 		Examples:
 			'pihole-cloudsync --push' will push (upload) your lists to a Git repo
-			'pihole-cloudsync --pull' will pull (download) your lists from a Git repo
+			'pihole-cloudsync --pull' will pull (download) your lists from a Git repo from origin/master
+			'pihole-cloudsync --pull main' will pull (download) your lists from a Git repo from origin/main
 
 		Project Home: https://github.com/stevejenkins/pihole-cloudsync
 EOF

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -35,7 +35,7 @@ update='December 26, 2020'
 personal_git_dir='/usr/local/bin/my-pihole-lists'
 pihole_dir='/etc/pihole'
 gravity_db='/etc/pihole/gravity.db'
-dnsmasq_dir='/etc/dnsmasq.d/'
+dnsmasq_dir='/etc/dnsmasq.d'
 ad_list='adlist.csv'
 custom_list='custom.list'
 domain_list='domainlist.csv'
@@ -47,6 +47,33 @@ cname_list='05-pihole-custom-cname.conf'
 SUDO=''
 if [ "$EUID" -ne 0 ]
   then SUDO='sudo'
+fi
+
+# Attempt to detect pihole running in Docker
+DOCKER=''
+DOCKER_CMD="$(command -v docker)"
+JQ_CMD="$(command -v jq)"
+if [ -n "${DOCKER_CMD}" ]
+then
+	CONTAINER="$(${DOCKER_CMD} ps -f "ancestor=pihole/pihole" --format "{{.Names}}")"
+	if [ -n "${CONTAINER}" ]
+	then
+		if [ -n "${JQ_CMD}" ]
+		then
+			echo "Found pihole running under Docker container '${CONTAINER}'"
+
+			pihole_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${pihole_dir}" '.[] | select(.Destination==$dir) | .Source')"
+			gravity_db="${pihole_dir}/gravity.db"
+			dnsmasq_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${dnsmasq_dir}" '.[] | select(.Destination==$dir) | .Source')"
+
+			echo "Found pihole directory mapped to '${pihole_dir}'"
+			echo "Found dnsmasq directory mapped to '${dnsmasq_dir}'"
+
+			DOCKER="${DOCKER_CMD} exec -i ${CONTAINER}"
+		else
+			echo "Found Docker container '${CONTAINER}' but jq is not installed"
+		fi
+	fi
 fi
 
 # FUNCTIONS
@@ -85,7 +112,7 @@ pull_initialize () {
 	$SUDO git reset --hard origin/master -q
 
 	# Stop DNS server
-	$SUDO service pihole-FTL stop
+	$SUDO ${DOCKER} service pihole-FTL stop
 
 	# Overwrite local files
 	$SUDO cp $custom_list $pihole_dir
@@ -98,7 +125,7 @@ pull_initialize () {
 	$SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
 
 	# Restart Pi-hole to pick up changes
-	$SUDO pihole -g
+	$SUDO ${DOCKER} pihole -g
 
 	# Display success messages
 	echo "Local Pi-hole initialized in Pull mode and first pull successfully completed.";
@@ -150,14 +177,14 @@ pull () {
                 # Remove -q option if you don't want to run in "quiet" mode
                 $SUDO git fetch --all -q
 		$SUDO git reset --hard origin/master -q
-                $SUDO service pihole-FTL stop
+                $SUDO ${DOCKER} service pihole-FTL stop
                 $SUDO cp $custom_list $pihole_dir
                 $SUDO cp $cname_list $dnsmasq_dir
                 $SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
                 $SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
                 $SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
                 $SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
-		$SUDO pihole -g
+		$SUDO ${DOCKER} pihole -g
                 echo 'Done!';
                 exit 0
         else

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -31,7 +31,7 @@ version='6.0.0'
 # Project Home: https://github.com/stevejenkins/pihole-cloudsync
 ###########################################################################
 # CONSTANTS
-personal_git_dir='/usr/local/bin/my-pihole-lists'
+personal_git_dir='/var/pihole-cloudsync'
 git_branch='main'
 git_remote=''
 action='pull'

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -39,9 +39,8 @@ do_init=0
 pihole_dir='/etc/pihole'
 gravity_db='/etc/pihole/gravity.db'
 dnsmasq_dir='/etc/dnsmasq.d'
-ad_list='adlist.csv'
+tables=("group" "adlist" "adlist_by_group" "client" "client_by_group" "domainlist" "domainlist_by_group")
 custom_list='custom.list'
-domain_list='domainlist.csv'
 cname_list='05-pihole-custom-cname.conf'
 ###########################################################################
 # SHOULDN'T NEED TO EDIT BELOW THIS LINE
@@ -94,47 +93,77 @@ usage() {
 		-v, --version                   Show the current version of pihole-cloudsync
 EOF
 }
+
 version() {
 	printf 'pihole-cloudsync v%s\n' "${version}"
 }
-push_initialize () {
-	# Go to Pi-hole directory, exit if doesn't exist
-	cd "${pihole_dir}" || exit
 
-	# Verify Custom and CNAME lists exist
-	${SUDO} touch "${custom_list}"
-	${SUDO} touch "${dnsmasq_dir}/${cname_list}"
+export_tables() {
+	# Export from Gravity database
+	for tab in "${tables[@]}"; do
+		${SUDO} sqlite3 "${gravity_db}" -header -csv "SELECT * FROM \"${tab}\"" >"${tab}.csv"
+	done
+}
 
+export_files() {
 	# Copy local Custom and CNAME lists to local Git repo
-	${SUDO} cp "${custom_list}" "${personal_git_dir}"
+	${SUDO} cp "${pihole_dir}/${custom_list}" "${personal_git_dir}"
 	${SUDO} cp "${dnsmasq_dir}/${cname_list}" "${personal_git_dir}"
+}
+
+import_tables() {
+	# Overwrite local database tables
+	for tab in "${tables[@]}"; do
+		${SUDO} sqlite3 "${gravity_db}" "DROP TABLE \"${tab}\""
+		${SUDO} sqlite3 "${gravity_db}" -header -csv ".import ${tab}.csv \"${tab}\""
+	done
+}
+
+import_files() {
+	# Overwrite local files
+	${SUDO} cp "${personal_git_dir}/${custom_list}" "${pihole_dir}"
+	${SUDO} cp "${personal_git_dir}/${cname_list}" "${dnsmasq_dir}"
+}
+
+do_git_push() {
+	cd "${personal_git_dir}" || exit
+	rightnow=$(date +"%B %e, %Y %l:%M%p")
+	${SUDO} git add .
+	${SUDO} git commit -a -m "Updated ${rightnow}" -q
+	${SUDO} git push -q -u origin "${git_branch}"
+}
+
+push_initialize () {
+	# Verify Custom and CNAME lists exist
+	${SUDO} touch "${pihole_dir}/${custom_list}"
+	${SUDO} touch "${dnsmasq_dir}/${cname_list}"
 
 	# Go to local Git repo directory
 	if [ ! -d "${personal_git_dir}" ]; then
 		${SUDO} mkdir "${personal_git_dir}"
 	fi
-	cd "${personal_git_dir}" || exit
 
-	# Export Ad and Domain lists from Gravity database
-	${SUDO} sqlite3 "${gravity_db}" -header -csv "SELECT * FROM adlist" >"${ad_list}"
-	${SUDO} sqlite3 "${gravity_db}" -header -csv "SELECT * FROM domainlist" >"${domain_list}"
-
-	# Add all lists to local Git repo
-	if [ ! -d ./.git ]; then
-		${SUDO} git init
+	if [ ! -d "${personal_git_dir}/.git" ]; then
+		${SUDO} git init "${personal_git_dir}"
 		${SUDO} git remote add origin "${git_remote}"
 	fi
-	${SUDO} git add .
-	rightnow=$(date +"%B %e, %Y %l:%M%p")
-	${SUDO} git commit -a -m "Updated ${rightnow}" -q
 	${SUDO} git branch -M "${git_branch}"
-	${SUDO} git push -q -u origin "${git_branch}"
+
+	# Add all lists to local Git repo
+	export_files
+	export_tables
+
+	do_git_push
 
 	printf 'Local Pi-hole initialized in Push mode and first push successfully completed.\n'
 	printf 'Future pushes can now be performed with "pihole-cloudsync --push".\n'
 }
+
 pull_initialize () {
 	# Go to Pi-hole directory, exit if doesn't exist
+	if [ ! -d "${personal_git_dir}" ]; then
+		${SUDO} git clone "${git_remote}" "${personal_git_dir}"
+	fi
 	cd "${personal_git_dir}" || exit
 
 	# Update local Git repo from remote Git repo
@@ -148,15 +177,8 @@ pull_initialize () {
 	# shellcheck disable=SC2086
 	${SUDO} ${DOCKER} service pihole-FTL stop
 
-	# Overwrite local files
-	${SUDO} cp "${custom_list}" "${pihole_dir}"
-	${SUDO} cp "${cname_list}" "${dnsmasq_dir}"
-
-	# Overwrite local database tables
-	${SUDO} sqlite3 "${gravity_db}" "DROP TABLE adlist;"
-	${SUDO} sqlite3 "${gravity_db}" -header -csv ".import adlist.csv adlist"
-	${SUDO} sqlite3 "${gravity_db}" "DROP TABLE domainlist;"
-	${SUDO} sqlite3 "${gravity_db}" -header -csv ".import domainlist.csv domainlist"
+	import_files
+	import_tables
 
 	# Restart Pi-hole to pick up changes
 	# shellcheck disable=SC2086
@@ -166,20 +188,13 @@ pull_initialize () {
 	printf 'Local Pi-hole initialized in Pull mode and first pull successfully completed\n'
 	printf 'Future pulls can now be perfomed with "pihole-cloudsync --pull"\n'
 }
-push () {
-	 # Go to Pi-hole directory, exit if doesn't exist
-	cd "${pihole_dir}" || exit
 
-	# Copy local Custom and CNAME lists to local Git repo
-	${SUDO} cp "${custom_list}" "${personal_git_dir}"
-	${SUDO} cp "${dnsmasq_dir}/${cname_list}" "${personal_git_dir}"
+push () {
+	export_files
+	export_tables
 
 	# Go to local Git repo directory
 	cd "${personal_git_dir}" || exit
-
-	# Export Ad and Domain lists from Gravity database
-	${SUDO} sqlite3 "${gravity_db}" -header -csv "SELECT * FROM adlist" >"${ad_list}"
-	${SUDO} sqlite3 "${gravity_db}" -header -csv "SELECT * FROM domainlist" >"${domain_list}"
 
 	# Compare local files to remote Git repo
 	${SUDO} git remote update > /dev/null
@@ -188,18 +203,14 @@ push () {
 	CHANGED=$(${SUDO} git --work-tree="${personal_git_dir}" status --porcelain)
 	if [ -n "${CHANGED}" ]; then
 		printf 'Local Pi-hole lists are different than remote Git repo. Updating remote repo...\n';
-		rightnow=$(date +"%B %e, %Y %l:%M%p")
-		# Remove -q option if you don't want to run in "quiet" mode
-		${SUDO} git commit -a -m "Updated ${rightnow}" -q
-		${SUDO} git push -q
+		do_git_push
 		printf 'Done!\n';
-		exit 0
 	else
 		# If local files are the same as remote, do nothing and exit
 		printf 'Remote Git repo matches local Pi-hole lists. No further action required.\n';
-		exit 0
 	fi
 }
+
 pull () {
 	# Go to Pi-hole directory, exit if doesn't exist
 	cd "${personal_git_dir}" || exit
@@ -214,19 +225,15 @@ pull () {
 		${SUDO} git reset --hard "origin/${git_branch}" -q
 		# shellcheck disable=SC2086
 		${SUDO} ${DOCKER} service pihole-FTL stop
-		${SUDO} cp "${custom_list}" "${pihole_dir}"
-		${SUDO} cp "${cname_list}" "${dnsmasq_dir}"
-		${SUDO} sqlite3 "${gravity_db}" "DROP TABLE adlist;"
-		${SUDO} sqlite3 "${gravity_db}" -header -csv ".import adlist.csv adlist"
-		${SUDO} sqlite3 "${gravity_db}" "DROP TABLE domainlist;"
-		${SUDO} sqlite3 "${gravity_db}" -header -csv ".import domainlist.csv domainlist"
+
+		import_files
+		import_tables
+
 		# shellcheck disable=SC2086
 		${SUDO} ${DOCKER} pihole -g
 		printf 'Done!\n';
-		exit 0
 	else
 		printf 'Local Pi-hole lists match remote Git repo. No further action required.\n';
-		exit 0
 	fi
 }
 

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -18,12 +18,12 @@ update='December 26, 2020'
 # USAGE: pihole-cloudsync <option>
 
 # OPTIONS:
-#  --initpush				Initialize Primary Pi-hole in "Push" mode
-#  --initpull				Initialize Secondary Pi-hole in "Pull" mode
-#  --push, --upload, --up, -u		Push (upload) your Pi-hole lists to a remote Git repo
-#  --pull, --download, --down, -d	Pull (download) your lists from a remote Git repo
-#  --help, -h, -?			Show the current version of pihole-cloudsync
-#  --version, -v			Show version number
+#  --initpush        Initialize Primary Pi-hole in "Push" mode
+#  --initpull        Initialize Secondary Pi-hole in "Pull" mode
+#  --push, --upload, --up, -u    Push (upload) your Pi-hole lists to a remote Git repo
+#  --pull, --download, --down, -d  Pull (download) your lists from a remote Git repo
+#  --help, -h, -?      Show the current version of pihole-cloudsync
+#  --version, -v      Show version number
 
 # EXAMPLES:
 #  'pihole-cloudsync --push' will push (upload) your lists to a remote Git repo
@@ -45,21 +45,18 @@ cname_list='05-pihole-custom-cname.conf'
 
 # Force sudo if not running with root privileges
 SUDO=''
-if [ "$EUID" -ne 0 ]
-  then SUDO='sudo'
+if [ "$EUID" -ne 0 ]; then
+	SUDO='sudo'
 fi
 
 # Attempt to detect pihole running in Docker
 DOCKER=''
 DOCKER_CMD="$(command -v docker)"
 JQ_CMD="$(command -v jq)"
-if [ -n "${DOCKER_CMD}" ]
-then
+if [ -n "${DOCKER_CMD}" ]; then
 	CONTAINER="$(${DOCKER_CMD} ps -f "ancestor=pihole/pihole" --format "{{.Names}}")"
-	if [ -n "${CONTAINER}" ]
-	then
-		if [ -n "${JQ_CMD}" ]
-		then
+	if [ -n "${CONTAINER}" ]; then
+		if [ -n "${JQ_CMD}" ]; then
 			echo "Found pihole running under Docker container '${CONTAINER}'"
 
 			pihole_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${pihole_dir}" '.[] | select(.Destination==$dir) | .Source')"
@@ -135,127 +132,119 @@ push () {
 	 # Go to Pi-hole directory, exit if doesn't exist
 	cd $pihole_dir || exit
 
-        # Copy local Custom and CNAME lists to local Git repo
-        $SUDO cp $custom_list $personal_git_dir
-        $SUDO cp $dnsmasq_dir/$cname_list $personal_git_dir
+	# Copy local Custom and CNAME lists to local Git repo
+	$SUDO cp $custom_list $personal_git_dir
+	$SUDO cp $dnsmasq_dir/$cname_list $personal_git_dir
 
 	# Go to local Git repo directory
-        cd $personal_git_dir || exit
+	cd $personal_git_dir || exit
 
-        # Export Ad and Domain lists from Gravity database
-        $SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM adlist" >$ad_list
-        $SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM domainlist" >$domain_list
+	# Export Ad and Domain lists from Gravity database
+	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM adlist" >$ad_list
+	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM domainlist" >$domain_list
 
 	# Compare local files to remote Git repo
 	$SUDO git remote update > /dev/null
 
 	# If local files are different than remote, update remote Git repo
-        CHANGED=$($SUDO git --work-tree=$personal_git_dir status --porcelain)
-        if [ -n "${CHANGED}" ]; then
-                echo 'Local Pi-hole lists are different than remote Git repo. Updating remote repo...';
+	CHANGED=$($SUDO git --work-tree=$personal_git_dir status --porcelain)
+	if [ -n "${CHANGED}" ]; then
+		echo 'Local Pi-hole lists are different than remote Git repo. Updating remote repo...';
 		rightnow=$(date +"%B %e, %Y %l:%M%p")
 		# Remove -q option if you don't want to run in "quiet" mode
 		$SUDO git commit -a -m "Updated $rightnow" -q
 		$SUDO git push -q
 		echo 'Done!';
 		exit 0
-        else
-	# If local files are the same as remote, do nothing and exit
-	echo 'Remote Git repo matches local Pi-hole lists. No further action required.';
+	else
+		# If local files are the same as remote, do nothing and exit
+		echo 'Remote Git repo matches local Pi-hole lists. No further action required.';
 		exit 0
-        fi
+	fi
 }
 pull () {
-        # Go to Pi-hole directory, exit if doesn't exist
+	# Go to Pi-hole directory, exit if doesn't exist
 	cd $personal_git_dir || exit
 
 	# Update local Git repo from remote Git repo
 	$SUDO git remote update > /dev/null
 	CHANGED=$($SUDO git log HEAD..origin/master --oneline)
 	if [ -n "${CHANGED}" ]; then
-                echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
-                # Remove -q option if you don't want to run in "quiet" mode
-                $SUDO git fetch --all -q
+		echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
+		# Remove -q option if you don't want to run in "quiet" mode
+		$SUDO git fetch --all -q
 		$SUDO git reset --hard origin/master -q
-                $SUDO ${DOCKER} service pihole-FTL stop
-                $SUDO cp $custom_list $pihole_dir
-                $SUDO cp $cname_list $dnsmasq_dir
-                $SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
-                $SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
-                $SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
-                $SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
+		$SUDO ${DOCKER} service pihole-FTL stop
+		$SUDO cp $custom_list $pihole_dir
+		$SUDO cp $cname_list $dnsmasq_dir
+		$SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
+		$SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
+		$SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
+		$SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
 		$SUDO ${DOCKER} pihole -g
-                echo 'Done!';
-                exit 0
-        else
-                echo 'Local Pi-hole lists match remote Git repo. No further action required.';
-                exit 0
-        fi
+		echo 'Done!';
+		exit 0
+	else
+		echo 'Local Pi-hole lists match remote Git repo. No further action required.';
+		exit 0
+	fi
 }
 ###########################################################################
 # Check to see whether a command line option was provided
-if [ -z "$1" ]
-  then
-    echo "Missing command line option. Try --push, --pull, or --help."
-    exit 1
+if [ -z "$1" ]; then
+		echo "Missing command line option. Try --push, --pull, or --help."
+		exit 1
 fi
 # Determine which action to perform (InitPush, InitPull, Push, Pull, or Help)
-for arg in "$@"
-do
-    # Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-    if [ "$arg" == "--initpush" ]
-    then
-	echo "$arg option detected. Initializing local Git repo for Push/Upload.";
-	push_initialize
-	exit 0
-    # Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-    elif [ "$arg" == "--initpull" ]
-    then
-	echo "$arg option detected. Initializing local Git repo for Pull/Download.";
-	pull_initialize
-	exit 0
-    # Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
-    elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ]
-    then
-	echo "$arg option detected. Running in Push/Upload mode."
-	push
-	exit 0
-    # Pull / Download - Pulls updated Pi-hole lists from remote Git repo
-    elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ]
-    then
-        echo "$arg option detected. Running in Pull/Download mode."
-	pull
-        exit 0
-    # Help - Displays help dialog
-    elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ]
-    then
-	cat << EOF
-Usage: pihole-cloudsync <option>
+for arg in "$@"; do
+	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
+	if [ "$arg" == "--initpush" ]; then
+		echo "$arg option detected. Initializing local Git repo for Push/Upload.";
+		push_initialize
+		exit 0
+	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
+	elif [ "$arg" == "--initpull" ]; then
+		echo "$arg option detected. Initializing local Git repo for Pull/Download.";
+		pull_initialize
+		exit 0
+	# Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
+	elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ]; then
+		echo "$arg option detected. Running in Push/Upload mode."
+		push
+		exit 0
+	# Pull / Download - Pulls updated Pi-hole lists from remote Git repo
+	elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ]; then
+		echo "$arg option detected. Running in Pull/Download mode."
+		pull
+		exit 0
+	# Help - Displays help dialog
+	elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ]; then
+		cat <<- EOF
+		Usage: pihole-cloudsync <option>
 
-Options:
-  --push, --upload, --up, -u		Push (upload) your Pi-hole lists to a remote Git repo
-  --pull, --download, --down, -d	Pull (download) your lists from a remote Git repo
-  --initpush				Initialize Primary Pi-hole in "Push" mode
-  --initpull				Initialize Secondary Pi-hole in "Pull" mode
-  --help, -h, -?			Show this help dialog
-  --version, -v				Show the current version of pihole-cloudsync
+		Options:
+			--push, --upload, --up, -u    Push (upload) your Pi-hole lists to a remote Git repo
+			--pull, --download, --down, -d  Pull (download) your lists from a remote Git repo
+			--initpush        Initialize Primary Pi-hole in "Push" mode
+			--initpull        Initialize Secondary Pi-hole in "Pull" mode
+			--help, -h, -?      Show this help dialog
+			--version, -v        Show the current version of pihole-cloudsync
 
-Examples:
-  'pihole-cloudsync --push' will push (upload) your lists to a Git repo
-  'pihole-cloudsync --pull' will pull (download) your lists from a Git repo
+		Examples:
+			'pihole-cloudsync --push' will push (upload) your lists to a Git repo
+			'pihole-cloudsync --pull' will pull (download) your lists from a Git repo
 
-Project Home: https://github.com/stevejenkins/pihole-cloudsync
+		Project Home: https://github.com/stevejenkins/pihole-cloudsync
 EOF
 
-    # Version - Displays version number
-    elif [ "$arg" == "--version" ] || [ "$arg" == "-v" ]
-	then
-	echo 'pihole-cloudsync v'$version' - Updated '"$update";
-	echo 'https://github.com/stevejenkins/pihole-cloudsync';
+	# Version - Displays version number
+	elif [ "$arg" == "--version" ] || [ "$arg" == "-v" ]; then
+		echo 'pihole-cloudsync v'$version' - Updated '"$update";
+		echo 'https://github.com/stevejenkins/pihole-cloudsync';
 
-    # Invalid command line option was passed
-    else
-	echo "Invalid command line option. Try --push, --pull, or --help."
-	exit 1
-    fi
+	# Invalid command line option was passed
+	else
+		echo "Invalid command line option. Try --push, --pull, or --help."
+		exit 1
+	fi
 done

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -7,7 +7,7 @@
 # Steve Jenkins (stevejenkins.com)
 # https://github.com/stevejenkins/pihole-cloudsync
 
-version='5.1'
+version='6.0.0'
 
 # SETUP
 # Follow the instructions in the README to set up your own private Git
@@ -32,6 +32,10 @@ version='5.1'
 ###########################################################################
 # CONSTANTS
 personal_git_dir='/usr/local/bin/my-pihole-lists'
+git_branch='main'
+git_remote=''
+action='pull'
+do_init=0
 pihole_dir='/etc/pihole'
 gravity_db='/etc/pihole/gravity.db'
 dnsmasq_dir='/etc/dnsmasq.d'
@@ -75,62 +79,88 @@ if [ -n "${DOCKER_CMD}" ]; then
 fi
 
 # FUNCTIONS
+usage() {
+	cat <<- EOF
+	Usage: pihole-cloudsync <option>
+
+	Options:
+		-u, --push, --upload, --up      Push (upload) your Pi-hole lists to a remote Git repo
+		-d, --pull, --download, --down  Pull (download) your lists from a remote Git repo
+		-i, --init                      Initialize Pi-hole in requested mode (--push/--pull)
+		-b <branch>, --branch <branch>  Use this branch (default: main)
+		-r <remote>. --remote <remote>  Use this git remote to initialize for push
+		-g <dir>, --destdir <dir>       Use this dir as the git repository location
+		-h, --help                      Show this help dialog
+		-v, --version                   Show the current version of pihole-cloudsync
+EOF
+}
+version() {
+	printf 'pihole-cloudsync v%s\n' "${version}"
+}
 push_initialize () {
 	# Go to Pi-hole directory, exit if doesn't exist
 	cd "${pihole_dir}" || exit
 
 	# Verify Custom and CNAME lists exist
-	"${SUDO}" touch "${custom_list}"
-	"${SUDO}" touch "${dnsmasq_dir}/${cname_list}"
+	${SUDO} touch "${custom_list}"
+	${SUDO} touch "${dnsmasq_dir}/${cname_list}"
 
 	# Copy local Custom and CNAME lists to local Git repo
-	"${SUDO}" cp "${custom_list}" "${personal_git_dir}"
-	"${SUDO}" cp "${dnsmasq_dir}/${cname_list}" "${personal_git_dir}"
+	${SUDO} cp "${custom_list}" "${personal_git_dir}"
+	${SUDO} cp "${dnsmasq_dir}/${cname_list}" "${personal_git_dir}"
 
 	# Go to local Git repo directory
+	if [ ! -d "${personal_git_dir}" ]; then
+		${SUDO} mkdir "${personal_git_dir}"
+	fi
 	cd "${personal_git_dir}" || exit
 
 	# Export Ad and Domain lists from Gravity database
-	"${SUDO}" sqlite3 "${gravity_db}" -header -csv "SELECT * FROM adlist" >"${ad_list}"
-	"${SUDO}" sqlite3 "${gravity_db}" -header -csv "SELECT * FROM domainlist" >"${domain_list}"
+	${SUDO} sqlite3 "${gravity_db}" -header -csv "SELECT * FROM adlist" >"${ad_list}"
+	${SUDO} sqlite3 "${gravity_db}" -header -csv "SELECT * FROM domainlist" >"${domain_list}"
 
 	# Add all lists to local Git repo
-	"${SUDO}" git add .
-	printf 'Local Pi-hole initialized in Push mode and local lists were added to local Git repo. Run "pihole-cloudsync --push" to push to remote Git repo.'
+	if [ ! -d ./.git ]; then
+		${SUDO} git init
+		${SUDO} git remote add origin "${git_remote}"
+	fi
+	${SUDO} git add .
+	rightnow=$(date +"%B %e, %Y %l:%M%p")
+	${SUDO} git commit -a -m "Updated ${rightnow}" -q
+	${SUDO} git branch -M "${git_branch}"
+	${SUDO} git push -q -u origin "${git_branch}"
+
+	printf 'Local Pi-hole initialized in Push mode and first push successfully completed.\n'
+	printf 'Future pushes can now be performed with "pihole-cloudsync --push".\n'
 }
 pull_initialize () {
-	branch=$1
-	if [ -z "${branch}" ]; then
-		branch="master"
-	fi
-
 	# Go to Pi-hole directory, exit if doesn't exist
-	cd $personal_git_dir || exit
+	cd "${personal_git_dir}" || exit
 
 	# Update local Git repo from remote Git repo
-	"${SUDO}" git remote update > /dev/null
+	${SUDO} git remote update > /dev/null
 
 	# Remove -q option if you don't want to run in "quiet" mode
-	"${SUDO}" git fetch --all -q
-	"${SUDO}" git reset --hard "origin/${branch}" -q
+	${SUDO} git fetch --all -q
+	${SUDO} git reset --hard "origin/${git_branch}" -q
 
 	# Stop DNS server
 	# shellcheck disable=SC2086
-	"${SUDO}" ${DOCKER} service pihole-FTL stop
+	${SUDO} ${DOCKER} service pihole-FTL stop
 
 	# Overwrite local files
-	"${SUDO}" cp "${custom_list}" "${pihole_dir}"
-	"${SUDO}" cp "${cname_list}" "${dnsmasq_dir}"
+	${SUDO} cp "${custom_list}" "${pihole_dir}"
+	${SUDO} cp "${cname_list}" "${dnsmasq_dir}"
 
 	# Overwrite local database tables
-	"${SUDO}" sqlite3 "${gravity_db}" "DROP TABLE adlist;"
-	"${SUDO}" sqlite3 "${gravity_db}" -header -csv ".import adlist.csv adlist"
-	"${SUDO}" sqlite3 "${gravity_db}" "DROP TABLE domainlist;"
-	"${SUDO}" sqlite3 "${gravity_db}" -header -csv ".import domainlist.csv domainlist"
+	${SUDO} sqlite3 "${gravity_db}" "DROP TABLE adlist;"
+	${SUDO} sqlite3 "${gravity_db}" -header -csv ".import adlist.csv adlist"
+	${SUDO} sqlite3 "${gravity_db}" "DROP TABLE domainlist;"
+	${SUDO} sqlite3 "${gravity_db}" -header -csv ".import domainlist.csv domainlist"
 
 	# Restart Pi-hole to pick up changes
 	# shellcheck disable=SC2086
-	"${SUDO}" ${DOCKER} pihole -g
+	${SUDO} ${DOCKER} pihole -g
 
 	# Display success messages
 	printf 'Local Pi-hole initialized in Pull mode and first pull successfully completed\n'
@@ -141,27 +171,27 @@ push () {
 	cd "${pihole_dir}" || exit
 
 	# Copy local Custom and CNAME lists to local Git repo
-	"${SUDO}" cp "${custom_list}" "${personal_git_dir}"
-	"${SUDO}" cp "${dnsmasq_dir}/${cname_list}" "${personal_git_dir}"
+	${SUDO} cp "${custom_list}" "${personal_git_dir}"
+	${SUDO} cp "${dnsmasq_dir}/${cname_list}" "${personal_git_dir}"
 
 	# Go to local Git repo directory
-	cd $personal_git_dir || exit
+	cd "${personal_git_dir}" || exit
 
 	# Export Ad and Domain lists from Gravity database
-	"${SUDO}" sqlite3 "${gravity_db}" -header -csv "SELECT * FROM adlist" >$ad_list
-	"${SUDO}" sqlite3 "${gravity_db}" -header -csv "SELECT * FROM domainlist" >$domain_list
+	${SUDO} sqlite3 "${gravity_db}" -header -csv "SELECT * FROM adlist" >"${ad_list}"
+	${SUDO} sqlite3 "${gravity_db}" -header -csv "SELECT * FROM domainlist" >"${domain_list}"
 
 	# Compare local files to remote Git repo
-	"${SUDO}" git remote update > /dev/null
+	${SUDO} git remote update > /dev/null
 
 	# If local files are different than remote, update remote Git repo
-	CHANGED=$("${SUDO}" git --work-tree=$personal_git_dir status --porcelain)
+	CHANGED=$(${SUDO} git --work-tree="${personal_git_dir}" status --porcelain)
 	if [ -n "${CHANGED}" ]; then
 		printf 'Local Pi-hole lists are different than remote Git repo. Updating remote repo...\n';
 		rightnow=$(date +"%B %e, %Y %l:%M%p")
 		# Remove -q option if you don't want to run in "quiet" mode
-		"${SUDO}" git commit -a -m "Updated $rightnow" -q
-		"${SUDO}" git push -q
+		${SUDO} git commit -a -m "Updated ${rightnow}" -q
+		${SUDO} git push -q
 		printf 'Done!\n';
 		exit 0
 	else
@@ -171,32 +201,27 @@ push () {
 	fi
 }
 pull () {
-	branch=$1
-	if [ -z "${branch}" ]; then
-		branch="master"
-	fi
-
 	# Go to Pi-hole directory, exit if doesn't exist
-	cd $personal_git_dir || exit
+	cd "${personal_git_dir}" || exit
 
 	# Update local Git repo from remote Git repo
-	"${SUDO}" git remote update > /dev/null
-	CHANGED=$("${SUDO}" git log HEAD..origin/${branch} --oneline)
+	${SUDO} git remote update > /dev/null
+	CHANGED=$(${SUDO} git log HEAD..origin/${git_branch} --oneline)
 	if [ -n "${CHANGED}" ]; then
 		printf 'Remote Git repo is different than local Pi-hole lists. Updating local lists...\n';
 		# Remove -q option if you don't want to run in "quiet" mode
-		"${SUDO}" git fetch --all -q
-		"${SUDO}" git reset --hard "origin/${branch}" -q
+		${SUDO} git fetch --all -q
+		${SUDO} git reset --hard "origin/${git_branch}" -q
 		# shellcheck disable=SC2086
-		"${SUDO}" ${DOCKER} service pihole-FTL stop
-		"${SUDO}" cp "${custom_list}" "${pihole_dir}"
-		"${SUDO}" cp "${cname_list}" "${dnsmasq_dir}"
-		"${SUDO}" sqlite3 "${gravity_db}" "DROP TABLE adlist;"
-		"${SUDO}" sqlite3 "${gravity_db}" -header -csv ".import adlist.csv adlist"
-		"${SUDO}" sqlite3 "${gravity_db}" "DROP TABLE domainlist;"
-		"${SUDO}" sqlite3 "${gravity_db}" -header -csv ".import domainlist.csv domainlist"
+		${SUDO} ${DOCKER} service pihole-FTL stop
+		${SUDO} cp "${custom_list}" "${pihole_dir}"
+		${SUDO} cp "${cname_list}" "${dnsmasq_dir}"
+		${SUDO} sqlite3 "${gravity_db}" "DROP TABLE adlist;"
+		${SUDO} sqlite3 "${gravity_db}" -header -csv ".import adlist.csv adlist"
+		${SUDO} sqlite3 "${gravity_db}" "DROP TABLE domainlist;"
+		${SUDO} sqlite3 "${gravity_db}" -header -csv ".import domainlist.csv domainlist"
 		# shellcheck disable=SC2086
-		"${SUDO}" ${DOCKER} pihole -g
+		${SUDO} ${DOCKER} pihole -g
 		printf 'Done!\n';
 		exit 0
 	else
@@ -204,65 +229,64 @@ pull () {
 		exit 0
 	fi
 }
-###########################################################################
-# Check to see whether a command line option was provided
-if [ -z "${1}" ]; then
-		printf 'Missing command line option. Try --push, --pull, or --help.\n' >&2
-		exit 1
-fi
-# Determine which action to perform (InitPush, InitPull, Push, Pull, or Help)
-for arg in "${@}"; do
-	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-	if [ "${arg}" == "--initpush" ]; then
-		printf '%s option detected. Initializing local Git repo for Push/Upload.\n' "${arg}"
-		push_initialize
-		exit 0
-	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-	elif [ "${arg}" == "--initpull" ]; then
-		printf '%s option detected. Initializing local Git repo for Pull/Download.\n' "${arg}";
-		shift
-		pull_initialize "${1}"
-		exit 0
-	# Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
-	elif [ "${arg}" == "--push" ] || [ "${arg}" == "--upload" ] || [ "${arg}" == "--up" ] || [ "${arg}" == "-u" ]; then
-		printf '%s option detected. Running in Push/Upload mode.\n' "${arg}"
-		push
-		exit 0
-	# Pull / Download - Pulls updated Pi-hole lists from remote Git repo
-	elif [ "${arg}" == "--pull" ] || [ "${arg}" == "--download" ] || [ "${arg}" == "--down" ]|| [ "${arg}" == "-d" ]; then
-		printf '%s option detected. Running in Pull/Download mode.\n' "${arg}"
-		shift
-		pull "${1}"
-		exit 0
-	# Help - Displays help dialog
-	elif [ "${arg}" == "--help" ] || [ "${arg}" == "-h" ] || [ "${arg}" == "-?" ]; then
-		cat <<- EOF
-		Usage: pihole-cloudsync <option>
 
-		Options:
-			--push, --upload, --up, -u               Push (upload) your Pi-hole lists to a remote Git repo
-			--pull, --download, --down, -d [branch]  Pull (download) your lists from a remote Git repo
-			--initpush                               Initialize Primary Pi-hole in "Push" mode
-			--initpull [branch]                      Initialize Secondary Pi-hole in "Pull" mode with optional branch (default: master)
-			--help, -h, -?                           Show this help dialog
-			--version, -v                            Show the current version of pihole-cloudsync
-
-		Examples:
-			'pihole-cloudsync --push' will push (upload) your lists to a Git repo
-			'pihole-cloudsync --pull' will pull (download) your lists from a Git repo from origin/master
-			'pihole-cloudsync --pull main' will pull (download) your lists from a Git repo from origin/main
-
-		Project Home: https://github.com/jgoguen/pihole-cloudsync
-EOF
-
-	# Version - Displays version number
-	elif [ "${arg}" == "--version" ] || [ "${arg}" == "-v" ]; then
-		printf 'pihole-cloudsync v%s\n' "${version}"
-		printf 'https://github.com/jgoguen/pihole-cloudsync\n'
-
-	# Invalid command line option was passed
-	else
-		printf 'Invalid command line option "%s". Try --push, --pull, or --help.\n' "${arg}" >&2
-		exit 1
-	fi
+while :
+do
+	case "${1}" in
+		-h | --help)
+			usage
+			exit 0
+			;;
+		-v | --version)
+			version
+			exit 0
+			;;
+		-b | --branch)
+			git_branch="${2}"
+			shift 2
+			;;
+		-r | --remote)
+			git_remote="${2}"
+			shift 2
+			;;
+		-i | --init)
+			do_init=1
+			shift
+			;;
+		-u | --upload | --push | --up)
+			action='push'
+			shift
+			;;
+		-d | --pull | --download | --down)
+			action='pull'
+			shift
+			;;
+		-g | --destdir)
+			personal_git_dir="${2}"
+			shift 2
+			;;
+		*)
+			shift
+			break
+			;;
+	esac
 done
+
+# Determine which action to perform (InitPush, InitPull, Push, Pull)
+if [ "${action}" = 'push' ]; then
+	if [ "${do_init}" = 1 ]; then
+		printf 'Initializing local Git repo for Push/Upload.\n'
+		push_initialize
+	else
+		printf 'Running in Push/Upload mode.\n'
+		push
+	fi
+elif [ "${action}" = 'pull' ]; then
+	if [ "${do_init}" = 1 ]; then
+		printf 'Initializing local Git repo for Pull/Download.\n'
+		pull_initialize
+	else
+		printf 'Running in Pull/Download mode.\n'
+		pull
+	fi
+fi

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -56,7 +56,7 @@ if [ -n "${DOCKER_CMD}" ]; then
 	CONTAINER="$(${DOCKER_CMD} ps -f "ancestor=pihole/pihole" --format "{{.Names}}")"
 	if [ -n "${CONTAINER}" ]; then
 		if [ -n "${JQ_CMD}" ]; then
-			echo "Found pihole running under Docker container '${CONTAINER}'"
+			printf 'Found pihole running under Docker container "%s"\n' "${CONTAINER}"
 
 			# shellcheck disable=SC2016
 			pihole_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${pihole_dir}" '.[] | select(.Destination==$dir) | .Source')"
@@ -64,12 +64,12 @@ if [ -n "${DOCKER_CMD}" ]; then
 			# shellcheck disable=SC2016
 			dnsmasq_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${dnsmasq_dir}" '.[] | select(.Destination==$dir) | .Source')"
 
-			echo "Found pihole directory mapped to '${pihole_dir}'"
-			echo "Found dnsmasq directory mapped to '${dnsmasq_dir}'"
+			printf 'Found pihole directory mapped to "%s"\n' "${pihole_dir}"
+			printf 'Found dnsmasq directory mapped to "%s"\n' "${dnsmasq_dir}"
 
 			DOCKER="${DOCKER_CMD} exec -i ${CONTAINER}"
 		else
-			echo "Found Docker container '${CONTAINER}' but jq is not installed"
+			printf 'Found Docker container "%s" but jq is not installed\n' "${CONTAINER}"
 		fi
 	fi
 fi
@@ -96,7 +96,7 @@ push_initialize () {
 
 	# Add all lists to local Git repo
 	"${SUDO}" git add .
-	echo "Local Pi-hole initialized in Push mode and local lists were added to local Git repo. Run 'pihole-cloudsync --push' to push to remote Git repo.";
+	printf 'Local Pi-hole initialized in Push mode and local lists were added to local Git repo. Run "pihole-cloudsync --push" to push to remote Git repo.'
 }
 pull_initialize () {
 	branch=$1
@@ -133,8 +133,8 @@ pull_initialize () {
 	"${SUDO}" ${DOCKER} pihole -g
 
 	# Display success messages
-	echo "Local Pi-hole initialized in Pull mode and first pull successfully completed.";
-	echo "Future pulls can now be perfomed with 'pihole-cloudsync --pull'.";
+	printf 'Local Pi-hole initialized in Pull mode and first pull successfully completed\n'
+	printf 'Future pulls can now be perfomed with "pihole-cloudsync --pull"\n'
 }
 push () {
 	 # Go to Pi-hole directory, exit if doesn't exist
@@ -157,16 +157,16 @@ push () {
 	# If local files are different than remote, update remote Git repo
 	CHANGED=$("${SUDO}" git --work-tree=$personal_git_dir status --porcelain)
 	if [ -n "${CHANGED}" ]; then
-		echo 'Local Pi-hole lists are different than remote Git repo. Updating remote repo...';
+		printf 'Local Pi-hole lists are different than remote Git repo. Updating remote repo...\n';
 		rightnow=$(date +"%B %e, %Y %l:%M%p")
 		# Remove -q option if you don't want to run in "quiet" mode
 		"${SUDO}" git commit -a -m "Updated $rightnow" -q
 		"${SUDO}" git push -q
-		echo 'Done!';
+		printf 'Done!\n';
 		exit 0
 	else
 		# If local files are the same as remote, do nothing and exit
-		echo 'Remote Git repo matches local Pi-hole lists. No further action required.';
+		printf 'Remote Git repo matches local Pi-hole lists. No further action required.\n';
 		exit 0
 	fi
 }
@@ -183,7 +183,7 @@ pull () {
 	"${SUDO}" git remote update > /dev/null
 	CHANGED=$("${SUDO}" git log HEAD..origin/${branch} --oneline)
 	if [ -n "${CHANGED}" ]; then
-		echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
+		printf 'Remote Git repo is different than local Pi-hole lists. Updating local lists...\n';
 		# Remove -q option if you don't want to run in "quiet" mode
 		"${SUDO}" git fetch --all -q
 		"${SUDO}" git reset --hard "origin/${branch}" -q
@@ -197,40 +197,40 @@ pull () {
 		"${SUDO}" sqlite3 "${gravity_db}" -header -csv ".import domainlist.csv domainlist"
 		# shellcheck disable=SC2086
 		"${SUDO}" ${DOCKER} pihole -g
-		echo 'Done!';
+		printf 'Done!\n';
 		exit 0
 	else
-		echo 'Local Pi-hole lists match remote Git repo. No further action required.';
+		printf 'Local Pi-hole lists match remote Git repo. No further action required.\n';
 		exit 0
 	fi
 }
 ###########################################################################
 # Check to see whether a command line option was provided
 if [ -z "${1}" ]; then
-		echo "Missing command line option. Try --push, --pull, or --help."
+		printf 'Missing command line option. Try --push, --pull, or --help.\n' >&2
 		exit 1
 fi
 # Determine which action to perform (InitPush, InitPull, Push, Pull, or Help)
 for arg in "${@}"; do
 	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
 	if [ "${arg}" == "--initpush" ]; then
-		echo "${arg} option detected. Initializing local Git repo for Push/Upload.";
+		printf '%s option detected. Initializing local Git repo for Push/Upload.\n' "${arg}"
 		push_initialize
 		exit 0
 	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
 	elif [ "${arg}" == "--initpull" ]; then
-		echo "${arg} option detected. Initializing local Git repo for Pull/Download.";
+		printf '%s option detected. Initializing local Git repo for Pull/Download.\n' "${arg}";
 		shift
 		pull_initialize "${1}"
 		exit 0
 	# Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
 	elif [ "${arg}" == "--push" ] || [ "${arg}" == "--upload" ] || [ "${arg}" == "--up" ] || [ "${arg}" == "-u" ]; then
-		echo "${arg} option detected. Running in Push/Upload mode."
+		printf '%s option detected. Running in Push/Upload mode.\n' "${arg}"
 		push
 		exit 0
 	# Pull / Download - Pulls updated Pi-hole lists from remote Git repo
 	elif [ "${arg}" == "--pull" ] || [ "${arg}" == "--download" ] || [ "${arg}" == "--down" ]|| [ "${arg}" == "-d" ]; then
-		echo "${arg} option detected. Running in Pull/Download mode."
+		printf '%s option detected. Running in Pull/Download mode.\n' "${arg}"
 		shift
 		pull "${1}"
 		exit 0
@@ -242,10 +242,10 @@ for arg in "${@}"; do
 		Options:
 			--push, --upload, --up, -u               Push (upload) your Pi-hole lists to a remote Git repo
 			--pull, --download, --down, -d [branch]  Pull (download) your lists from a remote Git repo
-			--initpush                 Initialize Primary Pi-hole in "Push" mode
-			--initpull [branch]        Initialize Secondary Pi-hole in "Pull" mode with optional branch (default: master)
-			--help, -h, -?       Show this help dialog
-			--version, -v        Show the current version of pihole-cloudsync
+			--initpush                               Initialize Primary Pi-hole in "Push" mode
+			--initpull [branch]                      Initialize Secondary Pi-hole in "Pull" mode with optional branch (default: master)
+			--help, -h, -?                           Show this help dialog
+			--version, -v                            Show the current version of pihole-cloudsync
 
 		Examples:
 			'pihole-cloudsync --push' will push (upload) your lists to a Git repo
@@ -257,12 +257,12 @@ EOF
 
 	# Version - Displays version number
 	elif [ "${arg}" == "--version" ] || [ "${arg}" == "-v" ]; then
-		echo 'pihole-cloudsync v'$version;
-		echo 'https://github.com/jgoguen/pihole-cloudsync';
+		printf 'pihole-cloudsync v%s\n' "${version}"
+		printf 'https://github.com/jgoguen/pihole-cloudsync\n'
 
 	# Invalid command line option was passed
 	else
-		echo "Invalid command line option. Try --push, --pull, or --help."
+		printf 'Invalid command line option "%s". Try --push, --pull, or --help.\n' "${arg}" >&2
 		exit 1
 	fi
 done

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -7,8 +7,7 @@
 # Steve Jenkins (stevejenkins.com)
 # https://github.com/stevejenkins/pihole-cloudsync
 
-version='5.0'
-update='December 26, 2020'
+version='5.1'
 
 # SETUP
 # Follow the instructions in the README to set up your own private Git
@@ -59,8 +58,10 @@ if [ -n "${DOCKER_CMD}" ]; then
 		if [ -n "${JQ_CMD}" ]; then
 			echo "Found pihole running under Docker container '${CONTAINER}'"
 
+			# shellcheck disable=SC2016
 			pihole_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${pihole_dir}" '.[] | select(.Destination==$dir) | .Source')"
 			gravity_db="${pihole_dir}/gravity.db"
+			# shellcheck disable=SC2016
 			dnsmasq_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${dnsmasq_dir}" '.[] | select(.Destination==$dir) | .Source')"
 
 			echo "Found pihole directory mapped to '${pihole_dir}'"
@@ -76,25 +77,25 @@ fi
 # FUNCTIONS
 push_initialize () {
 	# Go to Pi-hole directory, exit if doesn't exist
-	cd $pihole_dir || exit
+	cd "${pihole_dir}" || exit
 
 	# Verify Custom and CNAME lists exist
-	$SUDO touch $custom_list
-	$SUDO touch $dnsmasq_dir/$cname_list
+	"${SUDO}" touch "${custom_list}"
+	"${SUDO}" touch "${dnsmasq_dir}/${cname_list}"
 
 	# Copy local Custom and CNAME lists to local Git repo
-	$SUDO cp $custom_list $personal_git_dir
-	$SUDO cp $dnsmasq_dir/$cname_list $personal_git_dir
+	"${SUDO}" cp "${custom_list}" "${personal_git_dir}"
+	"${SUDO}" cp "${dnsmasq_dir}/${cname_list}" "${personal_git_dir}"
 
 	# Go to local Git repo directory
-	cd $personal_git_dir || exit
+	cd "${personal_git_dir}" || exit
 
 	# Export Ad and Domain lists from Gravity database
-	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM adlist" >$ad_list
-	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM domainlist" >$domain_list
+	"${SUDO}" sqlite3 "${gravity_db}" -header -csv "SELECT * FROM adlist" >"${ad_list}"
+	"${SUDO}" sqlite3 "${gravity_db}" -header -csv "SELECT * FROM domainlist" >"${domain_list}"
 
 	# Add all lists to local Git repo
-	$SUDO git add .
+	"${SUDO}" git add .
 	echo "Local Pi-hole initialized in Push mode and local lists were added to local Git repo. Run 'pihole-cloudsync --push' to push to remote Git repo.";
 }
 pull_initialize () {
@@ -107,27 +108,29 @@ pull_initialize () {
 	cd $personal_git_dir || exit
 
 	# Update local Git repo from remote Git repo
-	$SUDO git remote update > /dev/null
+	"${SUDO}" git remote update > /dev/null
 
 	# Remove -q option if you don't want to run in "quiet" mode
-	$SUDO git fetch --all -q
-	$SUDO git reset --hard "origin/${branch}" -q
+	"${SUDO}" git fetch --all -q
+	"${SUDO}" git reset --hard "origin/${branch}" -q
 
 	# Stop DNS server
-	$SUDO ${DOCKER} service pihole-FTL stop
+	# shellcheck disable=SC2086
+	"${SUDO}" ${DOCKER} service pihole-FTL stop
 
 	# Overwrite local files
-	$SUDO cp $custom_list $pihole_dir
-	$SUDO cp $cname_list $dnsmasq_dir
+	"${SUDO}" cp "${custom_list}" "${pihole_dir}"
+	"${SUDO}" cp "${cname_list}" "${dnsmasq_dir}"
 
 	# Overwrite local database tables
-	$SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
-	$SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
-	$SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
-	$SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
+	"${SUDO}" sqlite3 "${gravity_db}" "DROP TABLE adlist;"
+	"${SUDO}" sqlite3 "${gravity_db}" -header -csv ".import adlist.csv adlist"
+	"${SUDO}" sqlite3 "${gravity_db}" "DROP TABLE domainlist;"
+	"${SUDO}" sqlite3 "${gravity_db}" -header -csv ".import domainlist.csv domainlist"
 
 	# Restart Pi-hole to pick up changes
-	$SUDO ${DOCKER} pihole -g
+	# shellcheck disable=SC2086
+	"${SUDO}" ${DOCKER} pihole -g
 
 	# Display success messages
 	echo "Local Pi-hole initialized in Pull mode and first pull successfully completed.";
@@ -135,30 +138,30 @@ pull_initialize () {
 }
 push () {
 	 # Go to Pi-hole directory, exit if doesn't exist
-	cd $pihole_dir || exit
+	cd "${pihole_dir}" || exit
 
 	# Copy local Custom and CNAME lists to local Git repo
-	$SUDO cp $custom_list $personal_git_dir
-	$SUDO cp $dnsmasq_dir/$cname_list $personal_git_dir
+	"${SUDO}" cp "${custom_list}" "${personal_git_dir}"
+	"${SUDO}" cp "${dnsmasq_dir}/${cname_list}" "${personal_git_dir}"
 
 	# Go to local Git repo directory
 	cd $personal_git_dir || exit
 
 	# Export Ad and Domain lists from Gravity database
-	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM adlist" >$ad_list
-	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM domainlist" >$domain_list
+	"${SUDO}" sqlite3 "${gravity_db}" -header -csv "SELECT * FROM adlist" >$ad_list
+	"${SUDO}" sqlite3 "${gravity_db}" -header -csv "SELECT * FROM domainlist" >$domain_list
 
 	# Compare local files to remote Git repo
-	$SUDO git remote update > /dev/null
+	"${SUDO}" git remote update > /dev/null
 
 	# If local files are different than remote, update remote Git repo
-	CHANGED=$($SUDO git --work-tree=$personal_git_dir status --porcelain)
+	CHANGED=$("${SUDO}" git --work-tree=$personal_git_dir status --porcelain)
 	if [ -n "${CHANGED}" ]; then
 		echo 'Local Pi-hole lists are different than remote Git repo. Updating remote repo...';
 		rightnow=$(date +"%B %e, %Y %l:%M%p")
 		# Remove -q option if you don't want to run in "quiet" mode
-		$SUDO git commit -a -m "Updated $rightnow" -q
-		$SUDO git push -q
+		"${SUDO}" git commit -a -m "Updated $rightnow" -q
+		"${SUDO}" git push -q
 		echo 'Done!';
 		exit 0
 	else
@@ -177,21 +180,23 @@ pull () {
 	cd $personal_git_dir || exit
 
 	# Update local Git repo from remote Git repo
-	$SUDO git remote update > /dev/null
-	CHANGED=$($SUDO git log HEAD..origin/${branch} --oneline)
+	"${SUDO}" git remote update > /dev/null
+	CHANGED=$("${SUDO}" git log HEAD..origin/${branch} --oneline)
 	if [ -n "${CHANGED}" ]; then
 		echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
 		# Remove -q option if you don't want to run in "quiet" mode
-		$SUDO git fetch --all -q
-		$SUDO git reset --hard "origin/${branch}" -q
-		$SUDO ${DOCKER} service pihole-FTL stop
-		$SUDO cp $custom_list $pihole_dir
-		$SUDO cp $cname_list $dnsmasq_dir
-		$SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
-		$SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
-		$SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
-		$SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
-		$SUDO ${DOCKER} pihole -g
+		"${SUDO}" git fetch --all -q
+		"${SUDO}" git reset --hard "origin/${branch}" -q
+		# shellcheck disable=SC2086
+		"${SUDO}" ${DOCKER} service pihole-FTL stop
+		"${SUDO}" cp "${custom_list}" "${pihole_dir}"
+		"${SUDO}" cp "${cname_list}" "${dnsmasq_dir}"
+		"${SUDO}" sqlite3 "${gravity_db}" "DROP TABLE adlist;"
+		"${SUDO}" sqlite3 "${gravity_db}" -header -csv ".import adlist.csv adlist"
+		"${SUDO}" sqlite3 "${gravity_db}" "DROP TABLE domainlist;"
+		"${SUDO}" sqlite3 "${gravity_db}" -header -csv ".import domainlist.csv domainlist"
+		# shellcheck disable=SC2086
+		"${SUDO}" ${DOCKER} pihole -g
 		echo 'Done!';
 		exit 0
 	else
@@ -201,36 +206,36 @@ pull () {
 }
 ###########################################################################
 # Check to see whether a command line option was provided
-if [ -z "$1" ]; then
+if [ -z "${1}" ]; then
 		echo "Missing command line option. Try --push, --pull, or --help."
 		exit 1
 fi
 # Determine which action to perform (InitPush, InitPull, Push, Pull, or Help)
-for arg in "$@"; do
+for arg in "${@}"; do
 	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-	if [ "$arg" == "--initpush" ]; then
-		echo "$arg option detected. Initializing local Git repo for Push/Upload.";
+	if [ "${arg}" == "--initpush" ]; then
+		echo "${arg} option detected. Initializing local Git repo for Push/Upload.";
 		push_initialize
 		exit 0
 	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-	elif [ "$arg" == "--initpull" ]; then
-		echo "$arg option detected. Initializing local Git repo for Pull/Download.";
+	elif [ "${arg}" == "--initpull" ]; then
+		echo "${arg} option detected. Initializing local Git repo for Pull/Download.";
 		shift
-		pull_initialize $1
+		pull_initialize "${1}"
 		exit 0
 	# Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
-	elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ]; then
-		echo "$arg option detected. Running in Push/Upload mode."
+	elif [ "${arg}" == "--push" ] || [ "${arg}" == "--upload" ] || [ "${arg}" == "--up" ] || [ "${arg}" == "-u" ]; then
+		echo "${arg} option detected. Running in Push/Upload mode."
 		push
 		exit 0
 	# Pull / Download - Pulls updated Pi-hole lists from remote Git repo
-	elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ]; then
-		echo "$arg option detected. Running in Pull/Download mode."
+	elif [ "${arg}" == "--pull" ] || [ "${arg}" == "--download" ] || [ "${arg}" == "--down" ]|| [ "${arg}" == "-d" ]; then
+		echo "${arg} option detected. Running in Pull/Download mode."
 		shift
-		pull $1
+		pull "${1}"
 		exit 0
 	# Help - Displays help dialog
-	elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ]; then
+	elif [ "${arg}" == "--help" ] || [ "${arg}" == "-h" ] || [ "${arg}" == "-?" ]; then
 		cat <<- EOF
 		Usage: pihole-cloudsync <option>
 
@@ -247,13 +252,13 @@ for arg in "$@"; do
 			'pihole-cloudsync --pull' will pull (download) your lists from a Git repo from origin/master
 			'pihole-cloudsync --pull main' will pull (download) your lists from a Git repo from origin/main
 
-		Project Home: https://github.com/stevejenkins/pihole-cloudsync
+		Project Home: https://github.com/jgoguen/pihole-cloudsync
 EOF
 
 	# Version - Displays version number
-	elif [ "$arg" == "--version" ] || [ "$arg" == "-v" ]; then
-		echo 'pihole-cloudsync v'$version' - Updated '"$update";
-		echo 'https://github.com/stevejenkins/pihole-cloudsync';
+	elif [ "${arg}" == "--version" ] || [ "${arg}" == "-v" ]; then
+		echo 'pihole-cloudsync v'$version;
+		echo 'https://github.com/jgoguen/pihole-cloudsync';
 
 	# Invalid command line option was passed
 	else

--- a/systemd/pihole-cloudsync.env
+++ b/systemd/pihole-cloudsync.env
@@ -1,0 +1,2 @@
+BRANCH=main
+DESTDIR=/var/local/pihole-cloudsync

--- a/systemd/pihole-cloudsync.slice
+++ b/systemd/pihole-cloudsync.slice
@@ -1,0 +1,6 @@
+[Unit]
+Description=pihole-cloudsync resource limiter slice
+Before=slices.target
+
+[Slice]
+CPUQuota=50%

--- a/systemd/pihole-cloudsync@.service
+++ b/systemd/pihole-cloudsync@.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=pihole cloud sync - %i
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/default/pihole-cloudsync.env
+ExecStart=/usr/local/bin/pihole-cloudsync --%i --branch $BRANCH --destdir $DESTDIR

--- a/systemd/pihole-cloudsync@.service
+++ b/systemd/pihole-cloudsync@.service
@@ -5,3 +5,4 @@ Description=pihole cloud sync - %i
 Type=oneshot
 EnvironmentFile=-/etc/default/pihole-cloudsync.env
 ExecStart=/usr/local/bin/pihole-cloudsync --%i --branch $BRANCH --destdir $DESTDIR
+Slice=pihole-cloudsync.slice

--- a/systemd/pihole-cloudsync@.timer
+++ b/systemd/pihole-cloudsync@.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=pihole cloud sync timer
+Wants=network-online.target
+
+[Timer]
+OnCalendar=*-*-* *:00/5:00
+RandomizedDelaySec=5min
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This teaches `pihole-cloudsync` how to look for pihole running in Docker and sync using files from the host directories mounted in the Docker container. It assumes the standard pihole Docker image is being used and not a custom image.

Also adds a couple commits to normalize indentation and style, and to allow using a branch other than master.