### PR TITLE
Building off of jgoguen's docker work added env files and custom domain support

### DIFF
--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -98,6 +98,11 @@ push_initialize () {
 	echo "Local Pi-hole initialized in Push mode and local lists were added to local Git repo. Run 'pihole-cloudsync --push' to push to remote Git repo.";
 }
 pull_initialize () {
+	branch=$1
+	if [ -z "${branch}" ]; then
+		branch="master"
+	fi
+
 	# Go to Pi-hole directory, exit if doesn't exist
 	cd $personal_git_dir || exit
 
@@ -106,7 +111,7 @@ pull_initialize () {
 
 	# Remove -q option if you don't want to run in "quiet" mode
 	$SUDO git fetch --all -q
-	$SUDO git reset --hard origin/master -q
+	$SUDO git reset --hard "origin/${branch}" -q
 
 	# Stop DNS server
 	$SUDO ${DOCKER} service pihole-FTL stop
@@ -163,17 +168,22 @@ push () {
 	fi
 }
 pull () {
+	branch=$1
+	if [ -z "${branch}" ]; then
+		branch="master"
+	fi
+
 	# Go to Pi-hole directory, exit if doesn't exist
 	cd $personal_git_dir || exit
 
 	# Update local Git repo from remote Git repo
 	$SUDO git remote update > /dev/null
-	CHANGED=$($SUDO git log HEAD..origin/master --oneline)
+	CHANGED=$($SUDO git log HEAD..origin/${branch} --oneline)
 	if [ -n "${CHANGED}" ]; then
 		echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
 		# Remove -q option if you don't want to run in "quiet" mode
 		$SUDO git fetch --all -q
-		$SUDO git reset --hard origin/master -q
+		$SUDO git reset --hard "origin/${branch}" -q
 		$SUDO ${DOCKER} service pihole-FTL stop
 		$SUDO cp $custom_list $pihole_dir
 		$SUDO cp $cname_list $dnsmasq_dir
@@ -205,7 +215,8 @@ for arg in "$@"; do
 	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
 	elif [ "$arg" == "--initpull" ]; then
 		echo "$arg option detected. Initializing local Git repo for Pull/Download.";
-		pull_initialize
+		shift
+		pull_initialize $1
 		exit 0
 	# Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
 	elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ]; then
@@ -215,7 +226,8 @@ for arg in "$@"; do
 	# Pull / Download - Pulls updated Pi-hole lists from remote Git repo
 	elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ]; then
 		echo "$arg option detected. Running in Pull/Download mode."
-		pull
+		shift
+		pull $1
 		exit 0
 	# Help - Displays help dialog
 	elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ]; then
@@ -223,16 +235,17 @@ for arg in "$@"; do
 		Usage: pihole-cloudsync <option>
 
 		Options:
-			--push, --upload, --up, -u    Push (upload) your Pi-hole lists to a remote Git repo
-			--pull, --download, --down, -d  Pull (download) your lists from a remote Git repo
-			--initpush        Initialize Primary Pi-hole in "Push" mode
-			--initpull        Initialize Secondary Pi-hole in "Pull" mode
-			--help, -h, -?      Show this help dialog
+			--push, --upload, --up, -u               Push (upload) your Pi-hole lists to a remote Git repo
+			--pull, --download, --down, -d [branch]  Pull (download) your lists from a remote Git repo
+			--initpush                 Initialize Primary Pi-hole in "Push" mode
+			--initpull [branch]        Initialize Secondary Pi-hole in "Pull" mode with optional branch (default: master)
+			--help, -h, -?       Show this help dialog
 			--version, -v        Show the current version of pihole-cloudsync
 
 		Examples:
 			'pihole-cloudsync --push' will push (upload) your lists to a Git repo
-			'pihole-cloudsync --pull' will pull (download) your lists from a Git repo
+			'pihole-cloudsync --pull' will pull (download) your lists from a Git repo from origin/master
+			'pihole-cloudsync --pull main' will pull (download) your lists from a Git repo from origin/main
 
 		Project Home: https://github.com/stevejenkins/pihole-cloudsync
 EOF

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -52,6 +52,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 ###########################################################################
 # CONSTANTS
 personal_git_dir="${GIT_CONFIG_DIR:-/usr/local/bin/my-pihole-lists}"
+git_branch="${GIT_BRANCH:-master}"
 pihole_dir="${PIHOLE_DIR:-/etc/pihole}"
 gravity_db="${GRAVITY_DB:-/etc/pihole/gravity.db}"
 dnsmasq_dir="${DNSMASQ_DIR:-/etc/dnsmasq.d}"
@@ -61,7 +62,7 @@ cname_list="${CNAME_LIST:-05-pihole-custom-cname.conf}"
 # SHOULDN'T NEED TO EDIT BELOW THIS LINE
 
 # List of DB tables we need to migrate between instances
-DB_TABLES="adlist domainlist group domainlist_by_group"
+DB_TABLES="${SYNC_TABLES:-adlist domainlist group domainlist_by_group}"
 DB_DUMP_FILE="db_dump.sql"
 
 # Force sudo if not running with root privileges
@@ -96,6 +97,7 @@ fi
 
 export_tables () {
     $SUDO sqlite3 $gravity_db ".dump --preserve-rowids $DB_TABLES" > $DB_DUMP_FILE
+    # sqlite3 doesn't have a drop option, so we inject it after the transaction is generated
     for t in $DB_TABLES; do
         sed -i "/BEGIN TRAN/a DROP TABLE IF EXISTS '$t';" $DB_DUMP_FILE
     done
@@ -129,11 +131,6 @@ push_initialize () {
     echo "Local Pi-hole initialized in Push mode and local lists were added to local Git repo. Run 'pihole-cloudsync --push' to push to remote Git repo.";
 }
 pull_initialize () {
-    branch=$1
-    if [ -z "${branch}" ]; then
-        branch="master"
-    fi
-
     # Go to Pi-hole directory, exit if doesn't exist
     cd $personal_git_dir || exit
 
@@ -142,7 +139,7 @@ pull_initialize () {
 
     # Remove -q option if you don't want to run in "quiet" mode
     $SUDO git fetch --all -q
-    $SUDO git reset --hard "origin/${branch}" -q
+    $SUDO git reset --hard "origin/${git_branch}" -q
 
     # Stop DNS server
     $SUDO ${DOCKER} service pihole-FTL stop
@@ -195,22 +192,17 @@ push () {
     fi
 }
 pull () {
-    branch=$1
-    if [ -z "${branch}" ]; then
-        branch="master"
-    fi
-
     # Go to Pi-hole directory, exit if doesn't exist
     cd $personal_git_dir || exit
 
     # Update local Git repo from remote Git repo
     $SUDO git remote update > /dev/null
-    CHANGED=$($SUDO git log HEAD..origin/${branch} --oneline)
+    CHANGED=$($SUDO git log HEAD..origin/${git_branch} --oneline)
     if [ -n "${CHANGED}" ]; then
         echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
         # Remove -q option if you don't want to run in "quiet" mode
         $SUDO git fetch --all -q
-        $SUDO git reset --hard "origin/${branch}" -q
+        $SUDO git reset --hard "origin/${git_branch}" -q
         $SUDO ${DOCKER} service pihole-FTL stop
         $SUDO cp $custom_list $pihole_dir
         $SUDO cp $cname_list $dnsmasq_dir
@@ -240,7 +232,8 @@ for arg in "$@"; do
     elif [ "$arg" == "--initpull" ]; then
         echo "$arg option detected. Initializing local Git repo for Pull/Download.";
         shift
-        pull_initialize $1
+        [ -n "$1" ] && git_branch="$1"
+        pull_initialize
         exit 0
     # Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
     elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ]; then
@@ -251,7 +244,8 @@ for arg in "$@"; do
     elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ]; then
         echo "$arg option detected. Running in Pull/Download mode."
         shift
-        pull $1
+        [ -n "$1" ] && git_branch="$1"
+        pull
         exit 0
     # Help - Displays help dialog
     elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ]; then

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -35,7 +35,7 @@ update='December 26, 2020'
 personal_git_dir='/usr/local/bin/my-pihole-lists'
 pihole_dir='/etc/pihole'
 gravity_db='/etc/pihole/gravity.db'
-dnsmasq_dir='/etc/dnsmasq.d/'
+dnsmasq_dir='/etc/dnsmasq.d'
 ad_list='adlist.csv'
 custom_list='custom.list'
 domain_list='domainlist.csv'
@@ -47,6 +47,33 @@ cname_list='05-pihole-custom-cname.conf'
 SUDO=''
 if [ "$EUID" -ne 0 ]
   then SUDO='sudo'
+fi
+
+# Attempt to detect pihole running in Docker
+DOCKER=''
+DOCKER_CMD="$(command -v docker)"
+JQ_CMD="$(command -v jq)"
+if [ -n "${DOCKER_CMD}" ]
+then
+	CONTAINER="$(${DOCKER_CMD} ps -f "ancestor=pihole/pihole" --format "{{.Names}}")"
+	if [ -n "${CONTAINER}" ]
+	then
+		if [ -n "${JQ_CMD}" ]
+		then
+			echo "Found pihole running under Docker container '${CONTAINER}'"
+
+			pihole_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${pihole_dir}" '.[] | select(.Destination==$dir) | .Source')"
+			gravity_db="${pihole_dir}/gravity.db"
+			dnsmasq_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${dnsmasq_dir}" '.[] | select(.Destination==$dir) | .Source')"
+
+			echo "Found pihole directory mapped to '${pihole_dir}'"
+			echo "Found dnsmasq directory mapped to '${dnsmasq_dir}'"
+
+			DOCKER="${DOCKER_CMD} exec -i ${CONTAINER}"
+		else
+			echo "Found Docker container '${CONTAINER}' but jq is not installed"
+		fi
+	fi
 fi
 
 # FUNCTIONS
@@ -85,7 +112,7 @@ pull_initialize () {
 	$SUDO git reset --hard origin/master -q
 
 	# Stop DNS server
-	$SUDO service pihole-FTL stop
+	$SUDO ${DOCKER} service pihole-FTL stop
 
 	# Overwrite local files
 	$SUDO cp $custom_list $pihole_dir
@@ -98,7 +125,7 @@ pull_initialize () {
 	$SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
 
 	# Restart Pi-hole to pick up changes
-	$SUDO pihole -g
+	$SUDO ${DOCKER} pihole -g
 
 	# Display success messages
 	echo "Local Pi-hole initialized in Pull mode and first pull successfully completed.";
@@ -150,14 +177,14 @@ pull () {
                 # Remove -q option if you don't want to run in "quiet" mode
                 $SUDO git fetch --all -q
 		$SUDO git reset --hard origin/master -q
-                $SUDO service pihole-FTL stop
+                $SUDO ${DOCKER} service pihole-FTL stop
                 $SUDO cp $custom_list $pihole_dir
                 $SUDO cp $cname_list $dnsmasq_dir
                 $SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
                 $SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
                 $SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
                 $SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
-		$SUDO pihole -g
+		$SUDO ${DOCKER} pihole -g
                 echo 'Done!';
                 exit 0
         else

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -46,7 +46,7 @@ cname_list='05-pihole-custom-cname.conf'
 # Force sudo if not running with root privileges
 SUDO=''
 if [ "$EUID" -ne 0 ]; then
-	SUDO='sudo'
+    SUDO='sudo'
 fi
 
 # Attempt to detect pihole running in Docker
@@ -54,210 +54,227 @@ DOCKER=''
 DOCKER_CMD="$(command -v docker)"
 JQ_CMD="$(command -v jq)"
 if [ -n "${DOCKER_CMD}" ]; then
-	CONTAINER="$(${DOCKER_CMD} ps -f "ancestor=pihole/pihole" --format "{{.Names}}")"
-	if [ -n "${CONTAINER}" ]; then
-		if [ -n "${JQ_CMD}" ]; then
-			echo "Found pihole running under Docker container '${CONTAINER}'"
+    CONTAINER="$(${DOCKER_CMD} ps -f "ancestor=pihole/pihole" --format "{{.Names}}")"
+    if [ -n "${CONTAINER}" ]; then
+        if [ -n "${JQ_CMD}" ]; then
+            echo "Found pihole running under Docker container '${CONTAINER}'"
 
-			pihole_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${pihole_dir}" '.[] | select(.Destination==$dir) | .Source')"
-			gravity_db="${pihole_dir}/gravity.db"
-			dnsmasq_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${dnsmasq_dir}" '.[] | select(.Destination==$dir) | .Source')"
+            pihole_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${pihole_dir}" '.[] | select(.Destination==$dir) | .Source')"
+            gravity_db="${pihole_dir}/gravity.db"
+            dnsmasq_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${dnsmasq_dir}" '.[] | select(.Destination==$dir) | .Source')"
 
-			echo "Found pihole directory mapped to '${pihole_dir}'"
-			echo "Found dnsmasq directory mapped to '${dnsmasq_dir}'"
+            echo "Found pihole directory mapped to '${pihole_dir}'"
+            echo "Found dnsmasq directory mapped to '${dnsmasq_dir}'"
 
-			DOCKER="${DOCKER_CMD} exec -i ${CONTAINER}"
-		else
-			echo "Found Docker container '${CONTAINER}' but jq is not installed"
-		fi
-	fi
+            DOCKER="${DOCKER_CMD} exec -i ${CONTAINER}"
+        else
+            echo "Found Docker container '${CONTAINER}' but jq is not installed"
+        fi
+    fi
 fi
+
+export_table () {
+    table="$1"
+
+    $SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM \"$table\"" >"${table}.csv"
+}
+
+import_table () {
+    table="$1"
+
+    $SUDO sqlite3 $gravity_db "DROP TABLE \"$table\";"
+    $SUDO sqlite3 $gravity_db -header -csv ".import \"${table}.csv\" \"$table\""
+}
 
 # FUNCTIONS
 push_initialize () {
-	# Go to Pi-hole directory, exit if doesn't exist
-	cd $pihole_dir || exit
+    # Go to Pi-hole directory, exit if doesn't exist
+    cd $pihole_dir || exit
 
-	# Verify Custom and CNAME lists exist
-	$SUDO touch $custom_list
-	$SUDO touch $dnsmasq_dir/$cname_list
+    # Verify Custom and CNAME lists exist
+    $SUDO touch $custom_list
+    $SUDO touch $dnsmasq_dir/$cname_list
 
-	# Copy local Custom and CNAME lists to local Git repo
-	$SUDO cp $custom_list $personal_git_dir
-	$SUDO cp $dnsmasq_dir/$cname_list $personal_git_dir
+    # Copy local Custom and CNAME lists to local Git repo
+    $SUDO cp $custom_list $personal_git_dir
+    $SUDO cp $dnsmasq_dir/$cname_list $personal_git_dir
 
-	# Go to local Git repo directory
-	cd $personal_git_dir || exit
+    # Go to local Git repo directory
+    cd $personal_git_dir || exit
 
-	# Export Ad and Domain lists from Gravity database
-	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM adlist" >$ad_list
-	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM domainlist" >$domain_list
+    # Export Ad and Domain lists from Gravity database
+    export_table "adlist"
+    export_table "domainlist"
+    export_table "group"
+    export_table "domainlist_by_group"
 
-	# Add all lists to local Git repo
-	$SUDO git add .
-	echo "Local Pi-hole initialized in Push mode and local lists were added to local Git repo. Run 'pihole-cloudsync --push' to push to remote Git repo.";
+    # Add all lists to local Git repo
+    $SUDO git add .
+    echo "Local Pi-hole initialized in Push mode and local lists were added to local Git repo. Run 'pihole-cloudsync --push' to push to remote Git repo.";
 }
 pull_initialize () {
-	branch=$1
-	if [ -z "${branch}" ]; then
-		branch="master"
-	fi
+    branch=$1
+    if [ -z "${branch}" ]; then
+        branch="master"
+    fi
 
-	# Go to Pi-hole directory, exit if doesn't exist
-	cd $personal_git_dir || exit
+    # Go to Pi-hole directory, exit if doesn't exist
+    cd $personal_git_dir || exit
 
-	# Update local Git repo from remote Git repo
-	$SUDO git remote update > /dev/null
+    # Update local Git repo from remote Git repo
+    $SUDO git remote update > /dev/null
 
-	# Remove -q option if you don't want to run in "quiet" mode
-	$SUDO git fetch --all -q
-	$SUDO git reset --hard "origin/${branch}" -q
+    # Remove -q option if you don't want to run in "quiet" mode
+    $SUDO git fetch --all -q
+    $SUDO git reset --hard "origin/${branch}" -q
 
-	# Stop DNS server
-	$SUDO ${DOCKER} service pihole-FTL stop
+    # Stop DNS server
+    $SUDO ${DOCKER} service pihole-FTL stop
 
-	# Overwrite local files
-	$SUDO cp $custom_list $pihole_dir
-	$SUDO cp $cname_list $dnsmasq_dir
+    # Overwrite local files
+    $SUDO cp $custom_list $pihole_dir
+    $SUDO cp $cname_list $dnsmasq_dir
 
-	# Overwrite local database tables
-	$SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
-	$SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
-	$SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
-	$SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
+    # Overwrite local database tables
+    import_table "adlist"
+    import_table "domainlist"
+    import_table "group"
+    import_table "domainlist_by_group"
 
-	# Restart Pi-hole to pick up changes
-	$SUDO ${DOCKER} pihole -g
+    # Restart Pi-hole to pick up changes
+    $SUDO ${DOCKER} pihole -g
 
-	# Display success messages
-	echo "Local Pi-hole initialized in Pull mode and first pull successfully completed.";
-	echo "Future pulls can now be perfomed with 'pihole-cloudsync --pull'.";
+    # Display success messages
+    echo "Local Pi-hole initialized in Pull mode and first pull successfully completed.";
+    echo "Future pulls can now be perfomed with 'pihole-cloudsync --pull'.";
 }
 push () {
-	 # Go to Pi-hole directory, exit if doesn't exist
-	cd $pihole_dir || exit
+     # Go to Pi-hole directory, exit if doesn't exist
+    cd $pihole_dir || exit
 
-	# Copy local Custom and CNAME lists to local Git repo
-	$SUDO cp $custom_list $personal_git_dir
-	$SUDO cp $dnsmasq_dir/$cname_list $personal_git_dir
+    # Copy local Custom and CNAME lists to local Git repo
+    $SUDO cp $custom_list $personal_git_dir
+    $SUDO cp $dnsmasq_dir/$cname_list $personal_git_dir
 
-	# Go to local Git repo directory
-	cd $personal_git_dir || exit
+    # Go to local Git repo directory
+    cd $personal_git_dir || exit
 
-	# Export Ad and Domain lists from Gravity database
-	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM adlist" >$ad_list
-	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM domainlist" >$domain_list
+    # Export Ad and Domain lists from Gravity database
+    export_table "adlist"
+    export_table "domainlist"
+    export_table "group"
+    export_table "domainlist_by_group"
 
-	# Compare local files to remote Git repo
-	$SUDO git remote update > /dev/null
+    # Compare local files to remote Git repo
+    $SUDO git remote update > /dev/null
 
-	# If local files are different than remote, update remote Git repo
-	CHANGED=$($SUDO git --work-tree=$personal_git_dir status --porcelain)
-	if [ -n "${CHANGED}" ]; then
-		echo 'Local Pi-hole lists are different than remote Git repo. Updating remote repo...';
-		rightnow=$(date +"%B %e, %Y %l:%M%p")
-		# Remove -q option if you don't want to run in "quiet" mode
-		$SUDO git commit -a -m "Updated $rightnow" -q
-		$SUDO git push -q
-		echo 'Done!';
-		exit 0
-	else
-		# If local files are the same as remote, do nothing and exit
-		echo 'Remote Git repo matches local Pi-hole lists. No further action required.';
-		exit 0
-	fi
+    # If local files are different than remote, update remote Git repo
+    CHANGED=$($SUDO git --work-tree=$personal_git_dir status --porcelain)
+    if [ -n "${CHANGED}" ]; then
+        echo 'Local Pi-hole lists are different than remote Git repo. Updating remote repo...';
+        rightnow=$(date +"%B %e, %Y %l:%M%p")
+        # Remove -q option if you don't want to run in "quiet" mode
+        $SUDO git commit -a -m "Updated $rightnow" -q
+        $SUDO git push -q
+        echo 'Done!';
+        exit 0
+    else
+        # If local files are the same as remote, do nothing and exit
+        echo 'Remote Git repo matches local Pi-hole lists. No further action required.';
+        exit 0
+    fi
 }
 pull () {
-	branch=$1
-	if [ -z "${branch}" ]; then
-		branch="master"
-	fi
+    branch=$1
+    if [ -z "${branch}" ]; then
+        branch="master"
+    fi
 
-	# Go to Pi-hole directory, exit if doesn't exist
-	cd $personal_git_dir || exit
+    # Go to Pi-hole directory, exit if doesn't exist
+    cd $personal_git_dir || exit
 
-	# Update local Git repo from remote Git repo
-	$SUDO git remote update > /dev/null
-	CHANGED=$($SUDO git log HEAD..origin/${branch} --oneline)
-	if [ -n "${CHANGED}" ]; then
-		echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
-		# Remove -q option if you don't want to run in "quiet" mode
-		$SUDO git fetch --all -q
-		$SUDO git reset --hard "origin/${branch}" -q
-		$SUDO ${DOCKER} service pihole-FTL stop
-		$SUDO cp $custom_list $pihole_dir
-		$SUDO cp $cname_list $dnsmasq_dir
-		$SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
-		$SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
-		$SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
-		$SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
-		$SUDO ${DOCKER} pihole -g
-		echo 'Done!';
-		exit 0
-	else
-		echo 'Local Pi-hole lists match remote Git repo. No further action required.';
-		exit 0
-	fi
+    # Update local Git repo from remote Git repo
+    $SUDO git remote update > /dev/null
+    CHANGED=$($SUDO git log HEAD..origin/${branch} --oneline)
+    if [ -n "${CHANGED}" ]; then
+        echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
+        # Remove -q option if you don't want to run in "quiet" mode
+        $SUDO git fetch --all -q
+        $SUDO git reset --hard "origin/${branch}" -q
+        $SUDO ${DOCKER} service pihole-FTL stop
+        $SUDO cp $custom_list $pihole_dir
+        $SUDO cp $cname_list $dnsmasq_dir
+        import_table "adlist"
+        import_table "domainlist"
+        import_table "group"
+        import_table "domainlist_by_group"
+        $SUDO ${DOCKER} pihole -g
+        echo 'Done!';
+        exit 0
+    else
+        echo 'Local Pi-hole lists match remote Git repo. No further action required.';
+        exit 0
+    fi
 }
 ###########################################################################
 # Check to see whether a command line option was provided
 if [ -z "$1" ]; then
-		echo "Missing command line option. Try --push, --pull, or --help."
-		exit 1
+        echo "Missing command line option. Try --push, --pull, or --help."
+        exit 1
 fi
 # Determine which action to perform (InitPush, InitPull, Push, Pull, or Help)
 for arg in "$@"; do
-	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-	if [ "$arg" == "--initpush" ]; then
-		echo "$arg option detected. Initializing local Git repo for Push/Upload.";
-		push_initialize
-		exit 0
-	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-	elif [ "$arg" == "--initpull" ]; then
-		echo "$arg option detected. Initializing local Git repo for Pull/Download.";
-		shift
-		pull_initialize $1
-		exit 0
-	# Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
-	elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ]; then
-		echo "$arg option detected. Running in Push/Upload mode."
-		push
-		exit 0
-	# Pull / Download - Pulls updated Pi-hole lists from remote Git repo
-	elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ]; then
-		echo "$arg option detected. Running in Pull/Download mode."
-		shift
-		pull $1
-		exit 0
-	# Help - Displays help dialog
-	elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ]; then
-		cat <<- EOF
-		Usage: pihole-cloudsync <option>
+    # Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
+    if [ "$arg" == "--initpush" ]; then
+        echo "$arg option detected. Initializing local Git repo for Push/Upload.";
+        push_initialize
+        exit 0
+    # Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
+    elif [ "$arg" == "--initpull" ]; then
+        echo "$arg option detected. Initializing local Git repo for Pull/Download.";
+        shift
+        pull_initialize $1
+        exit 0
+    # Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
+    elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ]; then
+        echo "$arg option detected. Running in Push/Upload mode."
+        push
+        exit 0
+    # Pull / Download - Pulls updated Pi-hole lists from remote Git repo
+    elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ]; then
+        echo "$arg option detected. Running in Pull/Download mode."
+        shift
+        pull $1
+        exit 0
+    # Help - Displays help dialog
+    elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ]; then
+        cat <<- EOF
+        Usage: pihole-cloudsync <option>
 
-		Options:
-			--push, --upload, --up, -u               Push (upload) your Pi-hole lists to a remote Git repo
-			--pull, --download, --down, -d [branch]  Pull (download) your lists from a remote Git repo
-			--initpush                 Initialize Primary Pi-hole in "Push" mode
-			--initpull [branch]        Initialize Secondary Pi-hole in "Pull" mode with optional branch (default: master)
-			--help, -h, -?       Show this help dialog
-			--version, -v        Show the current version of pihole-cloudsync
+        Options:
+            --push, --upload, --up, -u               Push (upload) your Pi-hole lists to a remote Git repo
+            --pull, --download, --down, -d [branch]  Pull (download) your lists from a remote Git repo
+            --initpush                 Initialize Primary Pi-hole in "Push" mode
+            --initpull [branch]        Initialize Secondary Pi-hole in "Pull" mode with optional branch (default: master)
+            --help, -h, -?       Show this help dialog
+            --version, -v        Show the current version of pihole-cloudsync
 
-		Examples:
-			'pihole-cloudsync --push' will push (upload) your lists to a Git repo
-			'pihole-cloudsync --pull' will pull (download) your lists from a Git repo from origin/master
-			'pihole-cloudsync --pull main' will pull (download) your lists from a Git repo from origin/main
+        Examples:
+            'pihole-cloudsync --push' will push (upload) your lists to a Git repo
+            'pihole-cloudsync --pull' will pull (download) your lists from a Git repo from origin/master
+            'pihole-cloudsync --pull main' will pull (download) your lists from a Git repo from origin/main
 
-		Project Home: https://github.com/stevejenkins/pihole-cloudsync
+        Project Home: https://github.com/stevejenkins/pihole-cloudsync
 EOF
 
-	# Version - Displays version number
-	elif [ "$arg" == "--version" ] || [ "$arg" == "-v" ]; then
-		echo 'pihole-cloudsync v'$version' - Updated '"$update";
-		echo 'https://github.com/stevejenkins/pihole-cloudsync';
+    # Version - Displays version number
+    elif [ "$arg" == "--version" ] || [ "$arg" == "-v" ]; then
+        echo 'pihole-cloudsync v'$version' - Updated '"$update";
+        echo 'https://github.com/stevejenkins/pihole-cloudsync';
 
-	# Invalid command line option was passed
-	else
-		echo "Invalid command line option. Try --push, --pull, or --help."
-		exit 1
-	fi
+    # Invalid command line option was passed
+    else
+        echo "Invalid command line option. Try --push, --pull, or --help."
+        exit 1
+    fi
 done

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -4,11 +4,25 @@
 # pihole-cloudsync
 # Helper script to keep multiple Pi-holes' lists synchronized via Git
 
+# ORIGINAL AUTHOR
 # Steve Jenkins (stevejenkins.com)
 # https://github.com/stevejenkins/pihole-cloudsync
 
-version='5.0'
-update='December 26, 2020'
+# Joel Goguen
+# https://github.com/jgoguen/pihole-cloudsync
+# * Provide docker support
+# * Allow non-master branches
+
+# Jon Stephens
+# https://github.com/wetnun/pihole-cloudsync
+# * Remove collection of csv files in favor of dump
+# * Move import/export to helper functions
+# * Allow ENV file so you don't have to edit git files
+# * Fix issue of custom whitelist/domains don't work in agents because of groups missing
+# * Removed hard tabs, I just don't like them
+
+version='6.0'
+update='December 9, 2021'
 
 # SETUP
 # Follow the instructions in the README to set up your own private Git
@@ -30,14 +44,19 @@ update='December 26, 2020'
 #  'pihole-cloudsync --pull' will pull (download) your lists from a remote Git repo
 
 # Project Home: https://github.com/stevejenkins/pihole-cloudsync
+
+# Create env.sh file with presets if you don't want to edit this file
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+[ -f "${SCRIPT_DIR}/env.sh" ] && source "${SCRIPT_DIR}/env.sh"
+
 ###########################################################################
 # CONSTANTS
-personal_git_dir='/data/pihole/pihole-config'
-pihole_dir='/etc/pihole'
-gravity_db='/etc/pihole/gravity.db'
-dnsmasq_dir='/etc/dnsmasq.d'
-custom_list='custom.list'
-cname_list='05-pihole-custom-cname.conf'
+personal_git_dir="${GIT_CONFIG_DIR:-/usr/local/bin/my-pihole-lists}"
+pihole_dir="${PIHOLE_DIR:-/etc/pihole}"
+gravity_db="${GRAVITY_DB:-/etc/pihole/gravity.db}"
+dnsmasq_dir="${DNSMASQ_DIR:-/etc/dnsmasq.d}"
+custom_list="${CUSTOM_LIST:-custom.list}"
+cname_list="${CNAME_LIST:-05-pihole-custom-cname.conf}"
 ###########################################################################
 # SHOULDN'T NEED TO EDIT BELOW THIS LINE
 

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -32,16 +32,18 @@ update='December 26, 2020'
 # Project Home: https://github.com/stevejenkins/pihole-cloudsync
 ###########################################################################
 # CONSTANTS
-personal_git_dir='/usr/local/bin/my-pihole-lists'
+personal_git_dir='/data/pihole/pihole-config'
 pihole_dir='/etc/pihole'
 gravity_db='/etc/pihole/gravity.db'
 dnsmasq_dir='/etc/dnsmasq.d'
-ad_list='adlist.csv'
 custom_list='custom.list'
-domain_list='domainlist.csv'
 cname_list='05-pihole-custom-cname.conf'
 ###########################################################################
 # SHOULDN'T NEED TO EDIT BELOW THIS LINE
+
+# List of DB tables we need to migrate between instances
+DB_TABLES="adlist domainlist group domainlist_by_group"
+DB_DUMP_FILE="db_dump.sql"
 
 # Force sudo if not running with root privileges
 SUDO=''
@@ -73,17 +75,15 @@ if [ -n "${DOCKER_CMD}" ]; then
     fi
 fi
 
-export_table () {
-    table="$1"
-
-    $SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM \"$table\"" >"${table}.csv"
+export_tables () {
+    $SUDO sqlite3 $gravity_db ".dump --preserve-rowids $DB_TABLES" > $DB_DUMP_FILE
+    for t in $DB_TABLES; do
+        sed -i "/BEGIN TRAN/a DROP TABLE IF EXISTS $t;" $DB_DUMP_FILE
+    done
 }
 
-import_table () {
-    table="$1"
-
-    $SUDO sqlite3 $gravity_db "DROP TABLE \"$table\";"
-    $SUDO sqlite3 $gravity_db -header -csv ".import \"${table}.csv\" \"$table\""
+import_tables () {
+    $SUDO sqlite3 $gravity_db ".read '|$DB_DUMP_FILE'"
 }
 
 # FUNCTIONS
@@ -103,10 +103,7 @@ push_initialize () {
     cd $personal_git_dir || exit
 
     # Export Ad and Domain lists from Gravity database
-    export_table "adlist"
-    export_table "domainlist"
-    export_table "group"
-    export_table "domainlist_by_group"
+    export_tables
 
     # Add all lists to local Git repo
     $SUDO git add .
@@ -136,10 +133,7 @@ pull_initialize () {
     $SUDO cp $cname_list $dnsmasq_dir
 
     # Overwrite local database tables
-    import_table "adlist"
-    import_table "domainlist"
-    import_table "group"
-    import_table "domainlist_by_group"
+    import_tables
 
     # Restart Pi-hole to pick up changes
     $SUDO ${DOCKER} pihole -g
@@ -160,10 +154,7 @@ push () {
     cd $personal_git_dir || exit
 
     # Export Ad and Domain lists from Gravity database
-    export_table "adlist"
-    export_table "domainlist"
-    export_table "group"
-    export_table "domainlist_by_group"
+    export_tables
 
     # Compare local files to remote Git repo
     $SUDO git remote update > /dev/null
@@ -204,10 +195,7 @@ pull () {
         $SUDO ${DOCKER} service pihole-FTL stop
         $SUDO cp $custom_list $pihole_dir
         $SUDO cp $cname_list $dnsmasq_dir
-        import_table "adlist"
-        import_table "domainlist"
-        import_table "group"
-        import_table "domainlist_by_group"
+        import_tables
         $SUDO ${DOCKER} pihole -g
         echo 'Done!';
         exit 0

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -18,12 +18,12 @@ update='December 26, 2020'
 # USAGE: pihole-cloudsync <option>
 
 # OPTIONS:
-#  --initpush				Initialize Primary Pi-hole in "Push" mode
-#  --initpull				Initialize Secondary Pi-hole in "Pull" mode
-#  --push, --upload, --up, -u		Push (upload) your Pi-hole lists to a remote Git repo
-#  --pull, --download, --down, -d	Pull (download) your lists from a remote Git repo
-#  --help, -h, -?			Show the current version of pihole-cloudsync
-#  --version, -v			Show version number
+#  --initpush        Initialize Primary Pi-hole in "Push" mode
+#  --initpull        Initialize Secondary Pi-hole in "Pull" mode
+#  --push, --upload, --up, -u    Push (upload) your Pi-hole lists to a remote Git repo
+#  --pull, --download, --down, -d  Pull (download) your lists from a remote Git repo
+#  --help, -h, -?      Show the current version of pihole-cloudsync
+#  --version, -v      Show version number
 
 # EXAMPLES:
 #  'pihole-cloudsync --push' will push (upload) your lists to a remote Git repo
@@ -45,21 +45,18 @@ cname_list='05-pihole-custom-cname.conf'
 
 # Force sudo if not running with root privileges
 SUDO=''
-if [ "$EUID" -ne 0 ]
-  then SUDO='sudo'
+if [ "$EUID" -ne 0 ]; then
+	SUDO='sudo'
 fi
 
 # Attempt to detect pihole running in Docker
 DOCKER=''
 DOCKER_CMD="$(command -v docker)"
 JQ_CMD="$(command -v jq)"
-if [ -n "${DOCKER_CMD}" ]
-then
+if [ -n "${DOCKER_CMD}" ]; then
 	CONTAINER="$(${DOCKER_CMD} ps -f "ancestor=pihole/pihole" --format "{{.Names}}")"
-	if [ -n "${CONTAINER}" ]
-	then
-		if [ -n "${JQ_CMD}" ]
-		then
+	if [ -n "${CONTAINER}" ]; then
+		if [ -n "${JQ_CMD}" ]; then
 			echo "Found pihole running under Docker container '${CONTAINER}'"
 
 			pihole_dir="$(${DOCKER_CMD} inspect -f "{{json .Mounts}}" "${CONTAINER}" | ${JQ_CMD} -r --arg dir "${pihole_dir}" '.[] | select(.Destination==$dir) | .Source')"
@@ -135,127 +132,119 @@ push () {
 	 # Go to Pi-hole directory, exit if doesn't exist
 	cd $pihole_dir || exit
 
-        # Copy local Custom and CNAME lists to local Git repo
-        $SUDO cp $custom_list $personal_git_dir
-        $SUDO cp $dnsmasq_dir/$cname_list $personal_git_dir
+	# Copy local Custom and CNAME lists to local Git repo
+	$SUDO cp $custom_list $personal_git_dir
+	$SUDO cp $dnsmasq_dir/$cname_list $personal_git_dir
 
 	# Go to local Git repo directory
-        cd $personal_git_dir || exit
+	cd $personal_git_dir || exit
 
-        # Export Ad and Domain lists from Gravity database
-        $SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM adlist" >$ad_list
-        $SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM domainlist" >$domain_list
+	# Export Ad and Domain lists from Gravity database
+	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM adlist" >$ad_list
+	$SUDO sqlite3 $gravity_db -header -csv "SELECT * FROM domainlist" >$domain_list
 
 	# Compare local files to remote Git repo
 	$SUDO git remote update > /dev/null
 
 	# If local files are different than remote, update remote Git repo
-        CHANGED=$($SUDO git --work-tree=$personal_git_dir status --porcelain)
-        if [ -n "${CHANGED}" ]; then
-                echo 'Local Pi-hole lists are different than remote Git repo. Updating remote repo...';
+	CHANGED=$($SUDO git --work-tree=$personal_git_dir status --porcelain)
+	if [ -n "${CHANGED}" ]; then
+		echo 'Local Pi-hole lists are different than remote Git repo. Updating remote repo...';
 		rightnow=$(date +"%B %e, %Y %l:%M%p")
 		# Remove -q option if you don't want to run in "quiet" mode
 		$SUDO git commit -a -m "Updated $rightnow" -q
 		$SUDO git push -q
 		echo 'Done!';
 		exit 0
-        else
-	# If local files are the same as remote, do nothing and exit
-	echo 'Remote Git repo matches local Pi-hole lists. No further action required.';
+	else
+		# If local files are the same as remote, do nothing and exit
+		echo 'Remote Git repo matches local Pi-hole lists. No further action required.';
 		exit 0
-        fi
+	fi
 }
 pull () {
-        # Go to Pi-hole directory, exit if doesn't exist
+	# Go to Pi-hole directory, exit if doesn't exist
 	cd $personal_git_dir || exit
 
 	# Update local Git repo from remote Git repo
 	$SUDO git remote update > /dev/null
 	CHANGED=$($SUDO git log HEAD..origin/master --oneline)
 	if [ -n "${CHANGED}" ]; then
-                echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
-                # Remove -q option if you don't want to run in "quiet" mode
-                $SUDO git fetch --all -q
+		echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
+		# Remove -q option if you don't want to run in "quiet" mode
+		$SUDO git fetch --all -q
 		$SUDO git reset --hard origin/master -q
-                $SUDO ${DOCKER} service pihole-FTL stop
-                $SUDO cp $custom_list $pihole_dir
-                $SUDO cp $cname_list $dnsmasq_dir
-                $SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
-                $SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
-                $SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
-                $SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
+		$SUDO ${DOCKER} service pihole-FTL stop
+		$SUDO cp $custom_list $pihole_dir
+		$SUDO cp $cname_list $dnsmasq_dir
+		$SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
+		$SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
+		$SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
+		$SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
 		$SUDO ${DOCKER} pihole -g
-                echo 'Done!';
-                exit 0
-        else
-                echo 'Local Pi-hole lists match remote Git repo. No further action required.';
-                exit 0
-        fi
+		echo 'Done!';
+		exit 0
+	else
+		echo 'Local Pi-hole lists match remote Git repo. No further action required.';
+		exit 0
+	fi
 }
 ###########################################################################
 # Check to see whether a command line option was provided
-if [ -z "$1" ]
-  then
-    echo "Missing command line option. Try --push, --pull, or --help."
-    exit 1
+if [ -z "$1" ]; then
+		echo "Missing command line option. Try --push, --pull, or --help."
+		exit 1
 fi
 # Determine which action to perform (InitPush, InitPull, Push, Pull, or Help)
-for arg in "$@"
-do
-    # Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-    if [ "$arg" == "--initpush" ]
-    then
-	echo "$arg option detected. Initializing local Git repo for Push/Upload.";
-	push_initialize
-	exit 0
-    # Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-    elif [ "$arg" == "--initpull" ]
-    then
-	echo "$arg option detected. Initializing local Git repo for Pull/Download.";
-	pull_initialize
-	exit 0
-    # Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
-    elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ]
-    then
-	echo "$arg option detected. Running in Push/Upload mode."
-	push
-	exit 0
-    # Pull / Download - Pulls updated Pi-hole lists from remote Git repo
-    elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ]
-    then
-        echo "$arg option detected. Running in Pull/Download mode."
-	pull
-        exit 0
-    # Help - Displays help dialog
-    elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ]
-    then
-	cat << EOF
-Usage: pihole-cloudsync <option>
+for arg in "$@"; do
+	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
+	if [ "$arg" == "--initpush" ]; then
+		echo "$arg option detected. Initializing local Git repo for Push/Upload.";
+		push_initialize
+		exit 0
+	# Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
+	elif [ "$arg" == "--initpull" ]; then
+		echo "$arg option detected. Initializing local Git repo for Pull/Download.";
+		pull_initialize
+		exit 0
+	# Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
+	elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ]; then
+		echo "$arg option detected. Running in Push/Upload mode."
+		push
+		exit 0
+	# Pull / Download - Pulls updated Pi-hole lists from remote Git repo
+	elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ]; then
+		echo "$arg option detected. Running in Pull/Download mode."
+		pull
+		exit 0
+	# Help - Displays help dialog
+	elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ]; then
+		cat <<- EOF
+		Usage: pihole-cloudsync <option>
 
-Options:
-  --push, --upload, --up, -u		Push (upload) your Pi-hole lists to a remote Git repo
-  --pull, --download, --down, -d	Pull (download) your lists from a remote Git repo
-  --initpush				Initialize Primary Pi-hole in "Push" mode
-  --initpull				Initialize Secondary Pi-hole in "Pull" mode
-  --help, -h, -?			Show this help dialog
-  --version, -v				Show the current version of pihole-cloudsync
+		Options:
+			--push, --upload, --up, -u    Push (upload) your Pi-hole lists to a remote Git repo
+			--pull, --download, --down, -d  Pull (download) your lists from a remote Git repo
+			--initpush        Initialize Primary Pi-hole in "Push" mode
+			--initpull        Initialize Secondary Pi-hole in "Pull" mode
+			--help, -h, -?      Show this help dialog
+			--version, -v        Show the current version of pihole-cloudsync
 
-Examples:
-  'pihole-cloudsync --push' will push (upload) your lists to a Git repo
-  'pihole-cloudsync --pull' will pull (download) your lists from a Git repo
+		Examples:
+			'pihole-cloudsync --push' will push (upload) your lists to a Git repo
+			'pihole-cloudsync --pull' will pull (download) your lists from a Git repo
 
-Project Home: https://github.com/stevejenkins/pihole-cloudsync
+		Project Home: https://github.com/stevejenkins/pihole-cloudsync
 EOF
 
-    # Version - Displays version number
-    elif [ "$arg" == "--version" ] || [ "$arg" == "-v" ]
-	then
-	echo 'pihole-cloudsync v'$version' - Updated '"$update";
-	echo 'https://github.com/stevejenkins/pihole-cloudsync';
+	# Version - Displays version number
+	elif [ "$arg" == "--version" ] || [ "$arg" == "-v" ]; then
+		echo 'pihole-cloudsync v'$version' - Updated '"$update";
+		echo 'https://github.com/stevejenkins/pihole-cloudsync';
 
-    # Invalid command line option was passed
-    else
-	echo "Invalid command line option. Try --push, --pull, or --help."
-	exit 1
-    fi
+	# Invalid command line option was passed
+	else
+		echo "Invalid command line option. Try --push, --pull, or --help."
+		exit 1
+	fi
 done

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -97,12 +97,12 @@ fi
 export_tables () {
     $SUDO sqlite3 $gravity_db ".dump --preserve-rowids $DB_TABLES" > $DB_DUMP_FILE
     for t in $DB_TABLES; do
-        sed -i "/BEGIN TRAN/a DROP TABLE IF EXISTS $t;" $DB_DUMP_FILE
+        sed -i "/BEGIN TRAN/a DROP TABLE IF EXISTS '$t';" $DB_DUMP_FILE
     done
 }
 
 import_tables () {
-    $SUDO sqlite3 $gravity_db ".read '|$DB_DUMP_FILE'"
+    $SUDO sqlite3 $gravity_db ".read $DB_DUMP_FILE"
 }
 
 # FUNCTIONS


### PR DESCRIPTION
I forked off of @jgoguen with his docker and branch support and added:
* moved from csv to dump file because of silly table name in db
* fixed bug with custom domains not working on agents because of missing group attribution
* use env.sh file to override most config options (my main node and agents use different structures) so no editing of git file required
* removed hard tabs (personal preference since all of my different shells tend to make things jump around but spaces are consistent)

The move to .dump from csv files also allows you to change one variable (I forgot to make it an override, should have done that) and just copy additional tables as needed. I have some domains I need to allow and I noticed that on my agents the domains showed up without group assignments (like 'default') so they never got applied and gravity always blocked things.

Potential improvements:
* put $branch into env.sh to avoid needing to pass it in
* setup DB_TABLES to allow overrides with env.sh