### PR TITLE
Fix for systemd service EXEC error: permission denied

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ Wants=pihole-cloudsync-update.timer
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/bin/pihole-cloudsync --pull
+User=root
+Group=root
+ExecStart=/usr/local/bin/pihole-cloudsync/pihole-cloudsync --pull
 Slice=pihole-cloudsync-update.slice
 
 [Install]


### PR DESCRIPTION
This fixes a systemd error in the original setup instructions. 

The error would appear like:
`Jan 03 12:03:27 RPI1 systemd[7852]: pihole-cloudsync-update.service: Failed to execute command: Permission Denied
Jan 03 12:03:27 RPI1 systemd[7852]: pihole-cloudsync-update.service: Failed at step EXEC spawning <some_file_location>`

The solution was to add in User= and Group= as well as specify the proper location of the pihole-cloudsync exectuable.

Opened PR to discuss and merge.