### PR TITLE
Fix bugs when importing from git repo

### DIFF
--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -150,10 +150,10 @@ pull_initialize () {
 
 	# Overwrite local database tables
 	$SUDO sqlite3 $gravity_db "DELETE FROM adlist;"
-	$SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
+	$SUDO sqlite3 $gravity_db -header -csv ".import --skip 1 adlist.csv adlist"
 	if [ -s domainlist.csv ]; then
 		$SUDO sqlite3 $gravity_db "DELETE FROM domainlist;"
-		$SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
+		$SUDO sqlite3 $gravity_db -header -csv ".import --skip 1 domainlist.csv domainlist"
 	fi
 
     # Restart Pi-hole to pick up changes
@@ -212,10 +212,10 @@ pull () {
                 $SUDO cp $custom_list $pihole_dir
                 $SUDO cp $cname_list $dnsmasq_dir
                 $SUDO sqlite3 $gravity_db "DELETE FROM adlist;"
-                $SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
+                $SUDO sqlite3 $gravity_db -header -csv ".import --skip 1 adlist.csv adlist"
                 if [ -s domainlist.csv ]; then
                     $SUDO sqlite3 $gravity_db "DELETE FROM domainlist;"
-                    $SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
+                    $SUDO sqlite3 $gravity_db -header -csv ".import --skip 1 domainlist.csv domainlist"
                 fi
 		$SUDO pihole -g
                 echo 'Done!';

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -67,8 +67,8 @@ DB_DUMP_FILE="db_dump.sql"
 
 # Force sudo if not running with root privileges
 SUDO=''
-if [ "$EUID" -ne 0 ]; then
-    SUDO='sudo'
+if [ "$EUID" -ne 0 ];
+  then SUDO='sudo'
 fi
 
 # Attempt to detect pihole running in Docker
@@ -217,40 +217,44 @@ pull () {
 }
 ###########################################################################
 # Check to see whether a command line option was provided
-if [ -z "$1" ]; then
-        echo "Missing command line option. Try --push, --pull, or --help."
-        exit 1
+if [ -z "$1" ];
+  then
+    echo "Missing command line option. Try --push, --pull, or --help."
+    exit 1
 fi
 # Determine which action to perform (InitPush, InitPull, Push, Pull, or Help)
 for arg in "$@"; do
     # Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-    if [ "$arg" == "--initpush" ]; then
-        echo "$arg option detected. Initializing local Git repo for Push/Upload.";
-        push_initialize
-        exit 0
+    if [ "$arg" == "--initpush" ];
+    then
+	echo "$arg option detected. Initializing local Git repo for Push/Upload.";
+	push_initialize
+	exit 0
     # Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
-    elif [ "$arg" == "--initpull" ]; then
-        echo "$arg option detected. Initializing local Git repo for Pull/Download.";
-        shift
-        [ -n "$1" ] && git_branch="$1"
-        pull_initialize
-        exit 0
+    elif [ "$arg" == "--initpull" ];
+    then
+	echo "$arg option detected. Initializing local Git repo for Pull/Download.";
+	pull_initialize
+	exit 0
     # Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
-    elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ]; then
-        echo "$arg option detected. Running in Push/Upload mode."
-        push
-        exit 0
+    elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ];
+    then
+	echo "$arg option detected. Running in Push/Upload mode."
+	push
+	exit 0
     # Pull / Download - Pulls updated Pi-hole lists from remote Git repo
-    elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ]; then
+    elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ];
+    then
         echo "$arg option detected. Running in Pull/Download mode."
         shift
         [ -n "$1" ] && git_branch="$1"
         pull
         exit 0
     # Help - Displays help dialog
-    elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ]; then
-        cat <<- EOF
-        Usage: pihole-cloudsync <option>
+    elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ];
+    then
+	cat << EOF
+Usage: pihole-cloudsync <option>
 
         Options:
             --push, --upload, --up, -u               Push (upload) your Pi-hole lists to a remote Git repo
@@ -269,9 +273,10 @@ for arg in "$@"; do
 EOF
 
     # Version - Displays version number
-    elif [ "$arg" == "--version" ] || [ "$arg" == "-v" ]; then
-        echo 'pihole-cloudsync v'$version' - Updated '"$update";
-        echo 'https://github.com/stevejenkins/pihole-cloudsync';
+    elif [ "$arg" == "--version" ] || [ "$arg" == "-v" ];
+	then
+	echo 'pihole-cloudsync v'$version' - Updated '"$update";
+	echo 'https://github.com/stevejenkins/pihole-cloudsync';
 
     # Invalid command line option was passed
     else

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -148,13 +148,13 @@ pull_initialize () {
     $SUDO cp $custom_list $pihole_dir
     $SUDO cp $cname_list $dnsmasq_dir
 
-	# Overwrite local database tables
-	$SUDO sqlite3 $gravity_db "DELETE FROM adlist;"
-	$SUDO sqlite3 $gravity_db -header -csv ".import --skip 1 adlist.csv adlist"
-	if [ -s domainlist.csv ]; then
-		$SUDO sqlite3 $gravity_db "DELETE FROM domainlist;"
-		$SUDO sqlite3 $gravity_db -header -csv ".import --skip 1 domainlist.csv domainlist"
-	fi
+    # Overwrite local database tables
+    $SUDO sqlite3 $gravity_db "DELETE FROM adlist;"
+    $SUDO sqlite3 $gravity_db -header -csv ".import --skip 1 adlist.csv adlist"
+    if [ -s domainlist.csv ]; then
+        $SUDO sqlite3 $gravity_db "DELETE FROM domainlist;"
+        $SUDO sqlite3 $gravity_db -header -csv ".import --skip 1 domainlist.csv domainlist"
+    fi
 
     # Restart Pi-hole to pick up changes
     $SUDO ${DOCKER} pihole -g
@@ -200,14 +200,14 @@ pull () {
     # Go to Pi-hole directory, exit if doesn't exist
     cd $personal_git_dir || exit
 
-	# Update local Git repo from remote Git repo
-	$SUDO git remote update > /dev/null
-	CHANGED=$($SUDO git log HEAD..origin/master --oneline)
-	if [ -n "${CHANGED}" ]; then
+    # Update local Git repo from remote Git repo
+    $SUDO git remote update > /dev/null
+    CHANGED=$($SUDO git log HEAD..origin/master --oneline)
+    if [ -n "${CHANGED}" ]; then
                 echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
                 # Remove -q option if you don't want to run in "quiet" mode
                 $SUDO git fetch --all -q
-		$SUDO git reset --hard origin/master -q
+        $SUDO git reset --hard origin/master -q
                 $SUDO service pihole-FTL stop
                 $SUDO cp $custom_list $pihole_dir
                 $SUDO cp $cname_list $dnsmasq_dir
@@ -217,7 +217,7 @@ pull () {
                     $SUDO sqlite3 $gravity_db "DELETE FROM domainlist;"
                     $SUDO sqlite3 $gravity_db -header -csv ".import --skip 1 domainlist.csv domainlist"
                 fi
-		$SUDO pihole -g
+        $SUDO pihole -g
                 echo 'Done!';
                 exit 0
         else
@@ -237,21 +237,21 @@ for arg in "$@"; do
     # Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
     if [ "$arg" == "--initpush" ];
     then
-	echo "$arg option detected. Initializing local Git repo for Push/Upload.";
-	push_initialize
-	exit 0
+    echo "$arg option detected. Initializing local Git repo for Push/Upload.";
+    push_initialize
+    exit 0
     # Initialize - adds primary Pi-hole's lists to local Git repo before first push/upload
     elif [ "$arg" == "--initpull" ];
     then
-	echo "$arg option detected. Initializing local Git repo for Pull/Download.";
-	pull_initialize
-	exit 0
+    echo "$arg option detected. Initializing local Git repo for Pull/Download.";
+    pull_initialize
+    exit 0
     # Push / Upload - Pushes updated local Pi-hole lists to remote Git repo
     elif [ "$arg" == "--push" ] || [ "$arg" == "--upload" ] || [ "$arg" == "--up" ] || [ "$arg" == "-u" ];
     then
-	echo "$arg option detected. Running in Push/Upload mode."
-	push
-	exit 0
+    echo "$arg option detected. Running in Push/Upload mode."
+    push
+    exit 0
     # Pull / Download - Pulls updated Pi-hole lists from remote Git repo
     elif [ "$arg" == "--pull" ] || [ "$arg" == "--download" ] || [ "$arg" == "--down" ]|| [ "$arg" == "-d" ];
     then
@@ -263,7 +263,7 @@ for arg in "$@"; do
     # Help - Displays help dialog
     elif [ "$arg" == "--help" ] || [ "$arg" == "-h" ] || [ "$arg" == "-?" ];
     then
-	cat << EOF
+    cat << EOF
 Usage: pihole-cloudsync <option>
 
         Options:
@@ -284,9 +284,9 @@ EOF
 
     # Version - Displays version number
     elif [ "$arg" == "--version" ] || [ "$arg" == "-v" ];
-	then
-	echo 'pihole-cloudsync v'$version' - Updated '"$update";
-	echo 'https://github.com/stevejenkins/pihole-cloudsync';
+    then
+    echo 'pihole-cloudsync v'$version' - Updated '"$update";
+    echo 'https://github.com/stevejenkins/pihole-cloudsync';
 
     # Invalid command line option was passed
     else

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -149,10 +149,10 @@ pull_initialize () {
     $SUDO cp $cname_list $dnsmasq_dir
 
 	# Overwrite local database tables
-	$SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
+	$SUDO sqlite3 $gravity_db "DELETE FROM adlist;"
 	$SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
 	if [ -s domainlist.csv ]; then
-		$SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
+		$SUDO sqlite3 $gravity_db "DELETE FROM domainlist;"
 		$SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
 	fi
 
@@ -211,10 +211,10 @@ pull () {
                 $SUDO service pihole-FTL stop
                 $SUDO cp $custom_list $pihole_dir
                 $SUDO cp $cname_list $dnsmasq_dir
-                $SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
+                $SUDO sqlite3 $gravity_db "DELETE FROM adlist;"
                 $SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
                 if [ -s domainlist.csv ]; then
-                    $SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
+                    $SUDO sqlite3 $gravity_db "DELETE FROM domainlist;"
                     $SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
                 fi
 		$SUDO pihole -g

--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -148,8 +148,13 @@ pull_initialize () {
     $SUDO cp $custom_list $pihole_dir
     $SUDO cp $cname_list $dnsmasq_dir
 
-    # Overwrite local database tables
-    import_tables
+	# Overwrite local database tables
+	$SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
+	$SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
+	if [ -s domainlist.csv ]; then
+		$SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
+		$SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
+	fi
 
     # Restart Pi-hole to pick up changes
     $SUDO ${DOCKER} pihole -g
@@ -195,25 +200,30 @@ pull () {
     # Go to Pi-hole directory, exit if doesn't exist
     cd $personal_git_dir || exit
 
-    # Update local Git repo from remote Git repo
-    $SUDO git remote update > /dev/null
-    CHANGED=$($SUDO git log HEAD..origin/${git_branch} --oneline)
-    if [ -n "${CHANGED}" ]; then
-        echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
-        # Remove -q option if you don't want to run in "quiet" mode
-        $SUDO git fetch --all -q
-        $SUDO git reset --hard "origin/${git_branch}" -q
-        $SUDO ${DOCKER} service pihole-FTL stop
-        $SUDO cp $custom_list $pihole_dir
-        $SUDO cp $cname_list $dnsmasq_dir
-        import_tables
-        $SUDO ${DOCKER} pihole -g
-        echo 'Done!';
-        exit 0
-    else
-        echo 'Local Pi-hole lists match remote Git repo. No further action required.';
-        exit 0
-    fi
+	# Update local Git repo from remote Git repo
+	$SUDO git remote update > /dev/null
+	CHANGED=$($SUDO git log HEAD..origin/master --oneline)
+	if [ -n "${CHANGED}" ]; then
+                echo 'Remote Git repo is different than local Pi-hole lists. Updating local lists...';
+                # Remove -q option if you don't want to run in "quiet" mode
+                $SUDO git fetch --all -q
+		$SUDO git reset --hard origin/master -q
+                $SUDO service pihole-FTL stop
+                $SUDO cp $custom_list $pihole_dir
+                $SUDO cp $cname_list $dnsmasq_dir
+                $SUDO sqlite3 $gravity_db "DROP TABLE adlist;"
+                $SUDO sqlite3 $gravity_db -header -csv ".import adlist.csv adlist"
+                if [ -s domainlist.csv ]; then
+                    $SUDO sqlite3 $gravity_db "DROP TABLE domainlist;"
+                    $SUDO sqlite3 $gravity_db -header -csv ".import domainlist.csv domainlist"
+                fi
+		$SUDO pihole -g
+                echo 'Done!';
+                exit 0
+        else
+                echo 'Local Pi-hole lists match remote Git repo. No further action required.';
+                exit 0
+        fi
 }
 ###########################################################################
 # Check to see whether a command line option was provided


### PR DESCRIPTION
## TL;DR:
- Only modify domainlist table if there is content in domainlist.csv
- Switch `DROP TABLE` to `DELETE FROM`
- Skip first row when importing from csv
- Add some semicolons

## DROP vs DELETE
This addresses issue #40. An explanation can be seen in [this comment](https://github.com/stevejenkins/pihole-cloudsync/issues/40#issuecomment-1194760079) on the issue. Essentially, dropping the table is more destructive than what is needed when replacing the entries with the data from the csv files saved in git. Using the `DELETE` command preserves references, triggers, and other important information on the table.

## Only modify if there is csv content
I was running into issues where the script would crash if there was no content in domainlist.csv and the script tried to import from it. Obviously, if there is no content in the file it doesn't need to be imported so I just added a check to see if there is anything in the file before attempting an import and modifying the table.

## Ignore first line of csv when importing
The first line of the csv file should contain the column names from the SQL table. Skipping this line prevents errors and warnings when importing.

## Add some semicolons
I was running into some strange issues with the if statements while making changes and adding these semicolons seemed to solve them.